### PR TITLE
Fix squid lifetime statistics tracking

### DIFF
--- a/src/brain_about_tab.py
+++ b/src/brain_about_tab.py
@@ -256,9 +256,8 @@ class AboutTab(BrainBaseTab):
         if color.isValid():
             if self.tamagotchi_logic and self.tamagotchi_logic.squid:
                 self.tamagotchi_logic.squid.apply_tint(color)
-                if hasattr(self.tamagotchi_logic, 'brain_window') and \
-                hasattr(self.tamagotchi_logic.brain_window, 'statistics_tab'):
-                    self.tamagotchi_logic.brain_window.statistics_tab.increment_stat('times_colour_changed')
+                if hasattr(self.tamagotchi_logic, 'track_colour_changed'):
+                    self.tamagotchi_logic.track_colour_changed()
 
     def edit_name(self):
         """Allow user to edit squid name on double-click"""

--- a/src/brain_statistics_tab.py
+++ b/src/brain_statistics_tab.py
@@ -2,6 +2,7 @@ from PyQt5 import QtCore, QtGui, QtWidgets
 from .brain_base_tab import BrainBaseTab
 from .display_scaling import DisplayScaling
 from .localisation import Localisation
+from .squid_statistics import DEFAULT_NEURON_COUNT
 import time
 
 class StatisticsTab(BrainBaseTab):
@@ -26,7 +27,7 @@ class StatisticsTab(BrainBaseTab):
             'novelty_neurons_created': 0,
             'stress_neurons_created': 0,
             'reward_neurons_created': 0,
-            'current_neurons': 7,
+            'current_neurons': DEFAULT_NEURON_COUNT,
             'squid_age_minutes': 0,
             'last_position': None,
             'last_update_time': time.time()
@@ -244,7 +245,7 @@ class StatisticsTab(BrainBaseTab):
                 squid_stats = getattr(self.tamagotchi_logic.squid, 'statistics', None)
                 if squid_stats:
                     squid_stats.reset()
-                    self.tamagotchi_logic._observe_current_neuron_count()
+                    self.tamagotchi_logic.refresh_neuron_count()
                     self._sync_from_squid_statistics()
                     self.update_display()
 
@@ -276,7 +277,10 @@ class StatisticsTab(BrainBaseTab):
                     f.write(f"{loc.get('stat_sleep')}: {int(self.statistics['total_sleep_time'])}\n")
                     f.write(f"{loc.get('stat_sickness')}: {self.statistics['sickness_episodes']}\n")
                     f.write(f"{loc.get('stat_squid_age')}: {int(self.statistics['squid_age_minutes'])}\n")
-                    f.write(f"Max Neurons: {self.statistics.get('current_neurons', 7)}\n")
+                    f.write(
+                        "Max Neurons: "
+                        f"{self.statistics.get('current_neurons', DEFAULT_NEURON_COUNT)}\n"
+                    )
                     f.write("\n" + "=" * 30 + "\n")
                     f.write(f"{loc.get('export_end')}\n")
 

--- a/src/brain_statistics_tab.py
+++ b/src/brain_statistics_tab.py
@@ -41,21 +41,13 @@ class StatisticsTab(BrainBaseTab):
         self.update_timer.start(1000)  # Update every second
 
         self.is_visible = False
-        self.pending_distance = 0  # Store distance when tab not visible
-
-        # Connect to neuron creation events for real-time updates
-        if self.brain_widget and hasattr(self.brain_widget, 'neuronCreated'):
-            self.brain_widget.neuronCreated.connect(self._on_neuron_created_update_stats)
 
     def showEvent(self, event):
         """Called when tab becomes visible"""
         super().showEvent(event)
         self.is_visible = True
-        # Apply any pending distance
-        if self.pending_distance > 0:
-            self.statistics['distance_swam'] += self.pending_distance
-            self.pending_distance = 0
-            self.update_display()
+        self._sync_from_squid_statistics()
+        self.update_display()
 
     def hideEvent(self, event):
         """Called when tab becomes hidden"""
@@ -65,6 +57,8 @@ class StatisticsTab(BrainBaseTab):
     def set_logic(self, logic):
         """Called by main window after TamagotchiLogic (and squid) exist."""
         self.tamagotchi_logic = logic
+        self._sync_from_squid_statistics()
+        self.update_display()
 
     def _sync_from_squid_statistics(self):
         """Mirror the persistent squid statistics object into the tab state."""
@@ -103,58 +97,17 @@ class StatisticsTab(BrainBaseTab):
         if not squid_stats:
             return False
 
-        attr_map = {
-            'cheese_eaten': 'cheese_consumed',
-            'sushi_eaten': 'sushi_consumed',
-            'poops_created': 'poops_created',
-            'poops_thrown': 'total_poops_thrown',
-            'max_poops_cleaned': 'max_poops_cleaned',
-            'startles_experienced': 'startles_experienced',
-            'ink_clouds_created': 'ink_clouds_created',
-            'times_colour_changed': 'times_colour_changed',
-            'rocks_thrown': 'total_rocks_thrown',
-            'plants_interacted': 'plants_interacted',
-            'novelty_neurons_created': 'novelty_neurons_created',
-            'stress_neurons_created': 'stress_neurons_created',
-            'reward_neurons_created': 'reward_neurons_created',
-        }
-
-        attr_name = attr_map.get(stat_name)
-        if not attr_name or not hasattr(squid_stats, attr_name):
-            return False
-
-        current_value = getattr(squid_stats, attr_name, 0)
-        setattr(squid_stats, attr_name, current_value + amount)
-        return True
-
-    def update_current_neurons(self, count):
-        """Update the current neuron count in the UI, enforcing only-count-up logic.
-        
-        This ensures the max neurons stat only ever increases, never decreases.
-        """
-        if hasattr(self, 'stat_labels') and 'current_neurons' in self.stat_labels:
-            current_max = self.statistics.get('current_neurons', 0)
-            if count > current_max:
-                self.statistics['current_neurons'] = count
-                self.stat_labels['current_neurons'].setText(str(count))
-
-                if self.tamagotchi_logic and hasattr(self.tamagotchi_logic, 'squid'):
-                    squid = self.tamagotchi_logic.squid
-                    if hasattr(squid, 'statistics') and hasattr(squid.statistics, 'max_neurons_reached'):
-                        squid.statistics.max_neurons_reached = count
-                        squid.statistics.current_neurons = count
-
-    def _on_neuron_created_update_stats(self, neuron_name: str):
-        """Update current neuron count when a new neuron is created"""
-        self.update_statistics()
+        return squid_stats.increment(stat_name, amount)
 
     def track_distance(self, distance):
-        """Track distance swam - only updates if tab is visible"""
-        if self.is_visible:
-            self.statistics['distance_swam'] += distance
-            self.update_display()
-        else:
-            self.pending_distance += distance
+        """Forward a movement event to the canonical model."""
+        if self.tamagotchi_logic and getattr(self.tamagotchi_logic, 'squid', None):
+            squid_stats = getattr(self.tamagotchi_logic.squid, 'statistics', None)
+            if squid_stats:
+                squid_stats.add_distance(distance)
+                self._sync_from_squid_statistics()
+                if self.is_visible:
+                    self.update_display()
 
     def initialize_ui(self):
         """Build the statistics tab interface with DPI scaling"""
@@ -234,52 +187,17 @@ class StatisticsTab(BrainBaseTab):
         self.layout.addStretch()
 
     def update_from_brain_state(self, state):
-        """Update tab based on brain state"""
+        """Refresh the read-only mirror after a brain-state update."""
         if not self.tamagotchi_logic or not self.tamagotchi_logic.squid:
             return
 
-        squid = self.tamagotchi_logic.squid
-
-        current_pos = (squid.squid_x, squid.squid_y)
-        if self.statistics['last_position'] is not None:
-            last_pos = self.statistics['last_position']
-            distance = ((current_pos[0] - last_pos[0])**2 + (current_pos[1] - last_pos[1])**2)**0.5
-            self.statistics['distance_swam'] += distance
-
-        self.statistics['last_position'] = current_pos
-
-        if squid.is_sleeping:
-            current_time = time.time()
-            time_elapsed = current_time - self.statistics['last_update_time']
-            self.statistics['total_sleep_time'] += time_elapsed
-
-        self.statistics['last_update_time'] = time.time()
         self._sync_from_squid_statistics()
         self.update_display()
 
     def update_statistics(self):
-        """Update statistics from squid state"""
+        """Refresh the UI from the canonical squid statistics model."""
         if not self.tamagotchi_logic or not self.tamagotchi_logic.squid:
             return
-
-        squid = self.tamagotchi_logic.squid
-
-        if not self.brain_widget:
-            parent = self.parent()
-            if hasattr(parent, 'brain_widget'):
-                self.brain_widget = parent.brain_widget
-
-        if self.brain_widget and hasattr(self.brain_widget, 'neuron_positions'):
-            real_current_count = len(self.brain_widget.neuron_positions)
-            stored_count = self.statistics.get('current_neurons', 0)
-
-            if real_current_count > stored_count:
-                self.statistics['current_neurons'] = real_current_count
-
-                if hasattr(squid, 'statistics') and hasattr(squid.statistics, 'max_neurons_reached'):
-                    if real_current_count > squid.statistics.max_neurons_reached:
-                        squid.statistics.max_neurons_reached = real_current_count
-                        squid.statistics.current_neurons = real_current_count
 
         self._sync_from_squid_statistics()
         self.statistics['last_update_time'] = time.time()
@@ -305,17 +223,12 @@ class StatisticsTab(BrainBaseTab):
                 label.setText(str(int(value)))
 
     def increment_stat(self, stat_name, amount=1):
-        """Increment a specific statistic"""
-        updated_canonical = self._increment_squid_stat(stat_name, amount)
-
-        if stat_name in self.statistics:
-            self.statistics[stat_name] += amount
-        elif not updated_canonical:
+        """Forward a discrete event to the canonical model."""
+        if not self._increment_squid_stat(stat_name, amount):
             return
 
         self._sync_from_squid_statistics()
         self.update_display()
-        self.save_statistics()
 
     def reset_statistics(self):
         """Reset all statistics to zero"""
@@ -327,12 +240,12 @@ class StatisticsTab(BrainBaseTab):
         )
 
         if reply == QtWidgets.QMessageBox.Yes:
-            for key in self.statistics:
-                if key not in ['last_position', 'last_update_time']:
-                    self.statistics[key] = 0
-            self.statistics['last_update_time'] = time.time()
-            self.update_display()
-            self.save_statistics()
+            if self.tamagotchi_logic and getattr(self.tamagotchi_logic, 'squid', None):
+                squid_stats = getattr(self.tamagotchi_logic.squid, 'statistics', None)
+                if squid_stats:
+                    squid_stats.reset()
+                    self._sync_from_squid_statistics()
+                    self.update_display()
 
     def export_statistics(self):
         """Export statistics to a file"""
@@ -377,19 +290,9 @@ class StatisticsTab(BrainBaseTab):
                 )
 
     def save_statistics(self):
-        """Save statistics to file"""
-        if hasattr(self.tamagotchi_logic, 'save_manager'):
-            try:
-                self.tamagotchi_logic.save_manager.save_statistics(self.statistics)
-            except:
-                pass
+        """Compatibility hook; the main save pipeline persists the model."""
+        self._sync_from_squid_statistics()
 
     def load_statistics(self):
-        """Load statistics from file"""
-        if hasattr(self.tamagotchi_logic, 'save_manager'):
-            try:
-                loaded_stats = self.tamagotchi_logic.save_manager.load_statistics()
-                if loaded_stats:
-                    self.statistics.update(loaded_stats)
-            except:
-                pass
+        """Compatibility hook; the main load pipeline restores the model."""
+        self._sync_from_squid_statistics()

--- a/src/brain_statistics_tab.py
+++ b/src/brain_statistics_tab.py
@@ -89,26 +89,11 @@ class StatisticsTab(BrainBaseTab):
         self.statistics['current_neurons'] = getattr(squid_stats, 'max_neurons_reached', self.statistics['current_neurons'])
         self.statistics['squid_age_minutes'] = int(getattr(squid_stats, 'get_total_age_seconds', lambda: 0)() // 60)
 
-    def _increment_squid_stat(self, stat_name, amount=1):
-        """Increment the canonical squid statistics attribute for a tab stat key."""
-        if not self.tamagotchi_logic or not getattr(self.tamagotchi_logic, 'squid', None):
-            return False
-
-        squid_stats = getattr(self.tamagotchi_logic.squid, 'statistics', None)
-        if not squid_stats:
-            return False
-
-        return squid_stats.increment(stat_name, amount)
-
     def track_distance(self, distance):
-        """Forward a movement event to the canonical model."""
-        if self.tamagotchi_logic and getattr(self.tamagotchi_logic, 'squid', None):
-            squid_stats = getattr(self.tamagotchi_logic.squid, 'statistics', None)
-            if squid_stats:
-                squid_stats.add_distance(distance)
-                self._sync_from_squid_statistics()
-                if self.is_visible:
-                    self.update_display()
+        """Compatibility bridge; movement ownership remains in the logic/model."""
+        logic = self.tamagotchi_logic
+        if logic and hasattr(logic, 'track_distance'):
+            logic.track_distance(distance)
 
     def initialize_ui(self):
         """Build the statistics tab interface with DPI scaling"""
@@ -224,12 +209,10 @@ class StatisticsTab(BrainBaseTab):
                 label.setText(str(int(value)))
 
     def increment_stat(self, stat_name, amount=1):
-        """Forward a discrete event to the canonical model."""
-        if not self._increment_squid_stat(stat_name, amount):
-            return
-
-        self._sync_from_squid_statistics()
-        self.update_display()
+        """Compatibility bridge; event ownership remains in the logic/model."""
+        logic = self.tamagotchi_logic
+        if logic and hasattr(logic, 'record_statistic_event'):
+            logic.record_statistic_event(stat_name, amount)
 
     def reset_statistics(self):
         """Reset all statistics to zero"""

--- a/src/brain_statistics_tab.py
+++ b/src/brain_statistics_tab.py
@@ -244,6 +244,7 @@ class StatisticsTab(BrainBaseTab):
                 squid_stats = getattr(self.tamagotchi_logic.squid, 'statistics', None)
                 if squid_stats:
                     squid_stats.reset()
+                    self.tamagotchi_logic._observe_current_neuron_count()
                     self._sync_from_squid_statistics()
                     self.update_display()
 

--- a/src/brain_widget.py
+++ b/src/brain_widget.py
@@ -1173,10 +1173,7 @@ class BrainWidget(QtWidgets.QWidget):
             
             if neuron_name:
                 print(f"✨ Main thread: Created neuron {neuron_name}")
-                
-                # Emit signal to notify listeners (e.g., NetworkTab) of new neuron
-                self.neuronCreated.emit(neuron_name)
-                
+
                 # Handle pruning if needed
                 if self.pruning_enabled:
                     current_count = len(self.neuron_positions) - len(self.excluded_neurons)
@@ -1830,9 +1827,9 @@ class BrainWidget(QtWidgets.QWidget):
         else:
             # Fallback: synchronous check
             try:
-                result = self.check_neurogenesis_triggers(state_with_context)
-                if result:
-                    self._on_neurogenesis_complete({'should_create': True, **result})
+                # This path creates the neuron itself. The neurogenesis engine
+                # emits the same completed-birth event as the threaded path.
+                self.check_neurogenesis_triggers(state_with_context)
             except Exception as e:
                 print(f"⚠️ Error in neurogenesis check: {e}")
                 import traceback

--- a/src/interactions.py
+++ b/src/interactions.py
@@ -269,11 +269,7 @@ class RockInteractionManager:
             "is_positive": True
         }
 
-        # Update rocks thrown counter
-        if hasattr(self.squid, 'statistics'):
-            self.squid.statistics.total_rocks_thrown += 1
-
-        # Update statistics tab and achievements plugin
+        # Deliver the completed throw once to the canonical statistics model.
         if hasattr(self.logic, 'track_rock_thrown'):
             self.logic.track_rock_thrown()
         

--- a/src/interactions2.py
+++ b/src/interactions2.py
@@ -234,9 +234,9 @@ class PoopInteractionManager:
             "is_positive": False
         }
 
-        # Update poops thrown counter
-        if hasattr(self.squid, 'statistics'):
-            self.squid.statistics.total_poops_thrown += 1
+        # Deliver the completed throw once to the canonical statistics model.
+        if hasattr(self.logic, 'track_poop_thrown'):
+            self.logic.track_poop_thrown()
         
         # Add with moderate importance
         self.squid.memory_manager.add_short_term_memory(

--- a/src/neurogenesis.py
+++ b/src/neurogenesis.py
@@ -546,7 +546,14 @@ class EnhancedNeurogenesis:
         self.brain_widget.neurogenesis_highlight = {'neuron': neuron_name, 'start_time': time.time(), 'duration': 8.0 if trigger_type == 'connector' else 4.0, 'pulse_phase': 0}
         self._log_neuron_creation(neuron_name, trigger_type, spec, trigger_value_for_log)
         self._record_neurogenesis_memory(neuron_name)
+        self._notify_neuron_created(neuron_name)
         return neuron_name
+
+    def _notify_neuron_created(self, neuron_name: str):
+        """Emit one completed-birth event from the creation source."""
+        signal = getattr(self.brain_widget, 'neuronCreated', None)
+        if signal is not None:
+            signal.emit(neuron_name)
 
     def _record_neurogenesis_memory(self, neuron_name: str):
         """Permanently records a new neuron growth event in long-term memory."""
@@ -664,6 +671,7 @@ class EnhancedNeurogenesis:
         self.brain_widget.neurogenesis_highlight = {'neuron': neuron_name, 'start_time': time.time(), 'duration': 8.0, 'pulse_phase': 0}
         self.brain_widget.log_neurogenesis_event(neuron_name, "created", details={'trigger_type': 'connector', 'trigger_value': 1.0, 'specialization': 'orphan_rescue', 'display_name': func_neuron.display_name})
         self._record_neurogenesis_memory(neuron_name)
+        self._notify_neuron_created(neuron_name)
         print(f"🔗 Connector neuron {neuron_name} created to rescue {orphan_name} (connected to closest: {targets[0] if targets else 'None'})")
     
     def _set_neuron_appearance(self, name: str, func_neuron: FunctionalNeuron):

--- a/src/squid.py
+++ b/src/squid.py
@@ -1208,9 +1208,6 @@ class Squid:
                     'anxiety_reduction': True
                 })
 
-        if hasattr(self.tamagotchi_logic, 'brain_window') and hasattr(self.tamagotchi_logic.brain_window, 'statistics_tab'):
-            self.tamagotchi_logic.brain_window.statistics_tab.increment_stat('plants_interacted')
-
         # --- Reward for RL ---
         if hasattr(self.tamagotchi_logic, 'recent_positive_outcome'):
             self.tamagotchi_logic.recent_positive_outcome = True
@@ -1531,8 +1528,8 @@ class Squid:
 
         # Track distance - 80 pixels per movement
         if self.squid_x != prev_x or self.squid_y != prev_y:
-            if hasattr(self.tamagotchi_logic, 'brain_window') and hasattr(self.tamagotchi_logic.brain_window, 'statistics_tab'):
-                self.tamagotchi_logic.brain_window.statistics_tab.track_distance(80)
+            if hasattr(self.tamagotchi_logic, 'track_distance'):
+                self.tamagotchi_logic.track_distance(80)
 
         # Update animation frame and image
         if self.squid_direction in ["left", "right", "up", "down"]:
@@ -2383,5 +2380,4 @@ class Squid:
             self.update_squid_image()  # Changed to use method instead of direct pixmap set
         
         return distance
-
 

--- a/src/squid_statistics.py
+++ b/src/squid_statistics.py
@@ -267,8 +267,16 @@ class SquidStatistics:
         )
 
     def reset(self):
-        """Reset the canonical statistics model."""
+        """Reset counters without discarding live or lifetime neuron state."""
+        current_neurons = self.current_neurons
+        max_neurons_reached = self.max_neurons_reached
         self.__init__(self.squid)
+        self.current_neurons = current_neurons
+        self.max_neurons_reached = max(
+            self.max_neurons_reached,
+            max_neurons_reached,
+            current_neurons,
+        )
 
     def update(self, elapsed_seconds):
         """Advance continuous statistics by an explicit elapsed duration."""

--- a/src/squid_statistics.py
+++ b/src/squid_statistics.py
@@ -4,9 +4,64 @@ import math
 # Distance tracking constants
 DISTANCE_ROLLOVER_LIMIT = 999_999_999  # ~1 billion pixels before rollover
 
-class SquidStatistics:
-    def __init__(self, squid):
 
+class SquidStatistics:
+    """Canonical lifetime statistics for a squid.
+
+    Simulation code records elapsed time and discrete domain events here. UI
+    components may mirror these values, but they must not derive or persist
+    their own competing counters.
+    """
+
+    _PERSISTENCE_KEYS = {
+        'distance_swam': 'distance_swam',
+        'distance_swam_multiplier': 'distance_swam_multiplier',
+        'sushi_eaten': 'sushi_consumed',
+        'cheese_eaten': 'cheese_consumed',
+        'total_memories_formed': 'total_memories_formed',
+        'highest_anxiety': 'highest_anxiety',
+        'lowest_happiness': 'lowest_happiness',
+        'highest_satisfaction': 'highest_satisfaction',
+        'other_squids_encountered': 'other_squids_encountered',
+        'rocks_thrown': 'total_rocks_thrown',
+        'poops_thrown': 'total_poops_thrown',
+        'total_env_interactions': 'total_env_interactions',
+        'ink_clouds_created': 'ink_clouds_created',
+        'plants_interacted': 'plants_interacted',
+        'total_sleep_time': 'time_spent_asleep',
+        'peak_novelty': 'peak_novelty',
+        'peak_stress': 'peak_stress',
+        'peak_reward': 'peak_reward',
+        'novelty_neurons_created': 'novelty_neurons_created',
+        'stress_neurons_created': 'stress_neurons_created',
+        'reward_neurons_created': 'reward_neurons_created',
+        'poops_created': 'poops_created',
+        'max_poops_cleaned': 'max_poops_cleaned',
+        'startles_experienced': 'startles_experienced',
+        'times_colour_changed': 'times_colour_changed',
+        'sickness_episodes': 'sickness_episodes',
+    }
+
+    _EVENT_KEYS = {
+        'cheese_eaten': 'cheese_consumed',
+        'sushi_eaten': 'sushi_consumed',
+        'poops_created': 'poops_created',
+        'poops_thrown': 'total_poops_thrown',
+        'max_poops_cleaned': 'max_poops_cleaned',
+        'startles_experienced': 'startles_experienced',
+        'ink_clouds_created': 'ink_clouds_created',
+        'times_colour_changed': 'times_colour_changed',
+        'rocks_thrown': 'total_rocks_thrown',
+        'plants_interacted': 'plants_interacted',
+    }
+
+    _NEURON_BIRTH_KEYS = {
+        'novelty': 'novelty_neurons_created',
+        'stress': 'stress_neurons_created',
+        'reward': 'reward_neurons_created',
+    }
+
+    def __init__(self, squid):
         self.squid = squid
         self.start_time = time.time()
         self.total_age_seconds = 0
@@ -38,6 +93,7 @@ class SquidStatistics:
         self.sickness_episodes = 0
         self.max_neurons_reached = 7
         self.current_neurons = 7
+        self._last_sickness_state = bool(getattr(squid, 'is_sick', False))
 
     def get_total_age_seconds(self):
         """Calculates the total persistent age in seconds."""
@@ -59,6 +115,19 @@ class SquidStatistics:
                 self.squid.tamagotchi_logic.show_message(
                     f"🌊 Distance counter rolled over! Now at {self.distance_swam_multiplier}x"
                 )
+
+    def add_distance(self, distance):
+        """Track an already calculated distance without making a view own it."""
+        distance = float(distance)
+        if distance < 0 or not math.isfinite(distance):
+            raise ValueError("distance must be a finite non-negative number")
+
+        self.distance_swam += distance
+        if self.distance_swam >= DISTANCE_ROLLOVER_LIMIT:
+            rollovers, self.distance_swam = divmod(
+                self.distance_swam, DISTANCE_ROLLOVER_LIMIT
+            )
+            self.distance_swam_multiplier += int(rollovers)
     
     def get_distance_display(self):
         '''Get formatted distance string with multiplier if needed'''
@@ -89,49 +158,93 @@ class SquidStatistics:
         return f"{hours_str} hr" + ("s" if whole_hours + half_hour != 1 else "")
     
     def load_statistics(self, data):
-        """Load statistics from saved data dictionary"""
-        if not data:
-            return
-            
-        # Core stats
-        self.total_age_seconds = data.get('total_age_seconds', 0)
-        self.distance_swam = data.get('distance_swam', 0)
-        self.distance_swam_multiplier = data.get('distance_swam_multiplier', 1)
-        
-        # Food consumption
-        self.sushi_consumed = data.get('sushi_eaten', 0)
-        self.cheese_consumed = data.get('cheese_eaten', 0)
-        
-        # Mental states
-        self.highest_anxiety = data.get('highest_anxiety', 0)
-        self.lowest_happiness = data.get('lowest_happiness', 100)
-        
-        # Object interactions
-        self.total_rocks_thrown = data.get('rocks_thrown', 0)
-        self.total_poops_thrown = data.get('poops_thrown', 0)
-        self.ink_clouds_created = data.get('ink_clouds_created', 0)
-        self.plants_interacted = data.get('plants_interacted', 0)
-        
-        # Other tracked stats
-        self.times_colour_changed = data.get('times_colour_changed', 0)
-        self.poops_created = data.get('poops_created', 0)
-        self.max_poops_cleaned = data.get('max_poops_cleaned', 0)
-        self.startles_experienced = data.get('startles_experienced', 0)
-        
-        # Time and health
-        self.time_spent_asleep = data.get('total_sleep_time', 0)
-        self.sickness_episodes = data.get('sickness_episodes', 0)
-        
-        # Neurogenesis
-        self.novelty_neurons_created = data.get('novelty_neurons_created', 0)
-        self.stress_neurons_created = data.get('stress_neurons_created', 0)
-        self.reward_neurons_created = data.get('reward_neurons_created', 0)
-        
-        # --- FIX: Ensure these are loaded correctly, defaulting to 7 ---
-        self.max_neurons_reached = data.get('max_neurons_reached', 7)
-        self.current_neurons = data.get('current_neurons', 7)
+        """Load canonical statistics from a desktop ``statistics.json`` dict."""
+        if data:
+            self.total_age_seconds = data.get('total_age_seconds', 0)
+            self.start_time = time.time()
 
-    def update(self):
+            for persisted_key, attribute_name in self._PERSISTENCE_KEYS.items():
+                if persisted_key in data:
+                    setattr(self, attribute_name, data[persisted_key])
+
+            current_neurons = max(
+                0, int(data.get('current_neurons', self.current_neurons))
+            )
+            saved_maximum = data.get('max_neurons_reached', current_neurons)
+            if saved_maximum is None:
+                saved_maximum = current_neurons
+
+            self.current_neurons = current_neurons
+            self.max_neurons_reached = max(
+                current_neurons, max(0, int(saved_maximum))
+            )
+
+        # Loading an already-sick squid resumes the same episode. It must not
+        # manufacture a fresh false -> true transition on the next tick.
+        self._last_sickness_state = bool(getattr(self.squid, 'is_sick', False))
+
+    def to_dict(self):
+        """Return the canonical desktop persistence representation."""
+        total_age_seconds = self.get_total_age_seconds()
+        data = {
+            persisted_key: getattr(self, attribute_name)
+            for persisted_key, attribute_name in self._PERSISTENCE_KEYS.items()
+        }
+        data.update({
+            'total_age_seconds': total_age_seconds,
+            'squid_age_minutes': int(total_age_seconds // 60),
+            'max_neurons_reached': self.max_neurons_reached,
+            'current_neurons': self.current_neurons,
+        })
+        return data
+
+    def increment(self, event_name, amount=1):
+        """Increment a legacy gameplay event on the canonical model."""
+        attribute_name = self._EVENT_KEYS.get(event_name)
+        if not attribute_name:
+            return False
+
+        setattr(self, attribute_name, getattr(self, attribute_name) + amount)
+        return True
+
+    def record_sickness_state(self, is_sick):
+        """Record one sickness episode for each false -> true transition."""
+        is_sick = bool(is_sick)
+        if is_sick and not self._last_sickness_state:
+            self.sickness_episodes += 1
+        self._last_sickness_state = is_sick
+
+    def record_neuron_birth(self, neuron_type, current_count=None):
+        """Record a completed neurogenesis event exactly once at its source."""
+        counter_name = self._NEURON_BIRTH_KEYS.get(neuron_type)
+        if counter_name:
+            setattr(self, counter_name, getattr(self, counter_name) + 1)
+
+        if current_count is None:
+            current_count = self.current_neurons + 1
+        self.observe_neuron_count(current_count)
+
+    def observe_neuron_count(self, current_count):
+        """Update the live count while preserving the lifetime maximum."""
+        current_count = int(current_count)
+        if current_count < 0:
+            raise ValueError("current neuron count cannot be negative")
+
+        self.current_neurons = current_count
+        self.max_neurons_reached = max(
+            self.max_neurons_reached, current_count
+        )
+
+    def reset(self):
+        """Reset the canonical statistics model."""
+        self.__init__(self.squid)
+
+    def update(self, elapsed_seconds=1.0):
+        """Advance continuous statistics by an explicit elapsed duration."""
+        elapsed_seconds = float(elapsed_seconds)
+        if elapsed_seconds < 0 or not math.isfinite(elapsed_seconds):
+            raise ValueError("elapsed_seconds must be a finite non-negative number")
+
         # Update peak mental states
         if self.squid.anxiety > self.highest_anxiety:
             self.highest_anxiety = self.squid.anxiety
@@ -139,34 +252,9 @@ class SquidStatistics:
             self.lowest_happiness = self.squid.happiness
         if self.squid.satisfaction > self.highest_satisfaction:
             self.highest_satisfaction = self.squid.satisfaction
-            
+
         if self.squid.is_sleeping:
-            self.time_spent_asleep += 1 # update is called every second
-
-        # --- Check and update peak neurogenesis values ---
-        if self.squid.tamagotchi_logic and self.squid.tamagotchi_logic.brain_window:
-            brain_widget = self.squid.tamagotchi_logic.brain_window.brain_widget
-            if brain_widget:
-                # 1. Update Neurogenesis Stats
-                if hasattr(brain_widget, 'neurogenesis_data'):
-                    neuro_data = brain_widget.neurogenesis_data
-                    current_novelty = neuro_data.get('novelty_counter', 0)
-                    current_stress = neuro_data.get('stress_counter', 0)
-                    current_reward = neuro_data.get('reward_counter', 0)
-
-                    if current_novelty > self.peak_novelty:
-                        self.peak_novelty = current_novelty
-                    if current_stress > self.peak_stress:
-                        self.peak_stress = current_stress
-                    if current_reward > self.peak_reward:
-                        self.peak_reward = current_reward
-                
-                # 2. Update Max Neurons Reached (FIX)
-                if hasattr(brain_widget, 'neuron_positions'):
-                    actual_count = len(brain_widget.neuron_positions)
-                    if actual_count > self.max_neurons_reached:
-                        self.max_neurons_reached = actual_count
-                    self.current_neurons = actual_count
+            self.time_spent_asleep += elapsed_seconds
 
     def get_sleep_time(self):
         hours = int(self.time_spent_asleep // 3600)

--- a/src/squid_statistics.py
+++ b/src/squid_statistics.py
@@ -20,6 +20,8 @@ class SquidStatistics:
         'sushi_eaten': 'sushi_consumed',
         'cheese_eaten': 'cheese_consumed',
         'total_memories_formed': 'total_memories_formed',
+        'max_short_term_memories': 'max_short_term_memories',
+        'max_long_term_memories': 'max_long_term_memories',
         'highest_anxiety': 'highest_anxiety',
         'lowest_happiness': 'lowest_happiness',
         'highest_satisfaction': 'highest_satisfaction',
@@ -68,6 +70,8 @@ class SquidStatistics:
         self.sushi_consumed = 0
         self.cheese_consumed = 0
         self.total_memories_formed = 0
+        self.max_short_term_memories = 0
+        self.max_long_term_memories = 0
         self.highest_anxiety = 0
         self.lowest_happiness = 100
         self.highest_satisfaction = 0
@@ -233,6 +237,33 @@ class SquidStatistics:
         self.current_neurons = current_count
         self.max_neurons_reached = max(
             self.max_neurons_reached, current_count
+        )
+
+    def observe_poop_count(self, current_count):
+        """Preserve the largest number of simultaneous poop items."""
+        current_count = int(current_count)
+        if current_count < 0:
+            raise ValueError("current poop count cannot be negative")
+
+        self.max_poops_cleaned = max(
+            self.max_poops_cleaned,
+            current_count,
+        )
+
+    def observe_memory_counts(self, short_term_count, long_term_count):
+        """Preserve lifetime maxima for both memory stores."""
+        short_term_count = int(short_term_count)
+        long_term_count = int(long_term_count)
+        if short_term_count < 0 or long_term_count < 0:
+            raise ValueError("memory counts cannot be negative")
+
+        self.max_short_term_memories = max(
+            self.max_short_term_memories,
+            short_term_count,
+        )
+        self.max_long_term_memories = max(
+            self.max_long_term_memories,
+            long_term_count,
         )
 
     def reset(self):

--- a/src/squid_statistics.py
+++ b/src/squid_statistics.py
@@ -3,6 +3,7 @@ import math
 
 # Distance tracking constants
 DISTANCE_ROLLOVER_LIMIT = 999_999_999  # ~1 billion pixels before rollover
+DEFAULT_NEURON_COUNT = 8
 
 
 class SquidStatistics:
@@ -90,8 +91,8 @@ class SquidStatistics:
         self.startles_experienced = 0
         self.times_colour_changed = 0
         self.sickness_episodes = 0
-        self.max_neurons_reached = 7
-        self.current_neurons = 7
+        self.max_neurons_reached = DEFAULT_NEURON_COUNT
+        self.current_neurons = DEFAULT_NEURON_COUNT
         self._last_sickness_state = bool(getattr(squid, 'is_sick', False))
 
     def get_total_age_seconds(self):

--- a/src/squid_statistics.py
+++ b/src/squid_statistics.py
@@ -47,7 +47,6 @@ class SquidStatistics:
         'sushi_eaten': 'sushi_consumed',
         'poops_created': 'poops_created',
         'poops_thrown': 'total_poops_thrown',
-        'max_poops_cleaned': 'max_poops_cleaned',
         'startles_experienced': 'startles_experienced',
         'ink_clouds_created': 'ink_clouds_created',
         'times_colour_changed': 'times_colour_changed',
@@ -239,7 +238,7 @@ class SquidStatistics:
         """Reset the canonical statistics model."""
         self.__init__(self.squid)
 
-    def update(self, elapsed_seconds=1.0):
+    def update(self, elapsed_seconds):
         """Advance continuous statistics by an explicit elapsed duration."""
         elapsed_seconds = float(elapsed_seconds)
         if elapsed_seconds < 0 or not math.isfinite(elapsed_seconds):

--- a/src/tamagotchi_logic.py
+++ b/src/tamagotchi_logic.py
@@ -266,6 +266,30 @@ class TamagotchiLogic:
         Shows images/ng.png above the squid's head for 4 seconds
         and records a long-term memory of the event.
         """
+        brain_widget = getattr(self.brain_window, 'brain_widget', None)
+        neuron_type = None
+        current_count = None
+
+        if brain_widget:
+            current_count = len(getattr(brain_widget, 'neuron_positions', {}))
+            neurogenesis = getattr(brain_widget, 'enhanced_neurogenesis', None)
+            functional_neurons = getattr(neurogenesis, 'functional_neurons', {})
+            functional_neuron = functional_neurons.get(neuron_name)
+            neuron_type = getattr(functional_neuron, 'neuron_type', None)
+
+            if neuron_type is None:
+                details = getattr(brain_widget, 'neurogenesis_data', {}).get(
+                    'new_neurons_details', {}
+                ).get(neuron_name, {})
+                neuron_type = details.get('trigger_type')
+
+        self.track_neuron_creation(neuron_type, current_count)
+
+        # The creation signal is emitted before optional pruning. Re-observe
+        # the settled live count on the next event-loop turn without reducing
+        # the lifetime maximum recorded at birth.
+        QtCore.QTimer.singleShot(0, self._observe_current_neuron_count)
+
         # Show the ng icon above the squid's head for 4 seconds
         if hasattr(self.squid, 'show_neurogenesis_icon'):
             self.squid.show_neurogenesis_icon()
@@ -1138,9 +1162,6 @@ class TamagotchiLogic:
                 )
                 QtCore.QTimer.singleShot(5000, self.squid.end_ink_flee)
 
-            if hasattr(self.brain_window, 'statistics_tab'):
-                self.brain_window.statistics_tab.increment_stat('startles_experienced')
-
             # --- resilience / anxiety / ink logic --------------------------
             stress_neuron_count = 0
             if self.brain_window and hasattr(self.brain_window, 'brain_widget'):
@@ -1272,15 +1293,13 @@ class TamagotchiLogic:
         fade_out_animation.start()
         self.statistics_window.award(-250)
 
-        # Update ink clouds counter in squid.statistics (for save/load persistence)
+        # Record the event once on the canonical model.
         if hasattr(self, 'squid') and hasattr(self.squid, 'statistics'):
-            self.squid.statistics.ink_clouds_created = getattr(
-                self.squid.statistics, 'ink_clouds_created', 0
-            ) + 1
+            self.squid.statistics.increment('ink_clouds_created')
         
-        # Update ink clouds in brain statistics tab (for UI display)
+        # Refresh the read-only statistics projection.
         if hasattr(self.brain_window, 'statistics_tab'):
-            self.brain_window.statistics_tab.increment_stat('ink_clouds_created')
+            self.brain_window.statistics_tab.update_statistics()
         
         
         # Backup timer to force remove after 10 seconds in case animation fails
@@ -1329,9 +1348,13 @@ class TamagotchiLogic:
             self.brain_window.statistics_tab.increment_stat('poops_created')
             # Update max poops if needed
             current_poops = len(self.poop_items)
-            if current_poops > self.brain_window.statistics_tab.statistics['max_poops_cleaned']:
-                self.brain_window.statistics_tab.statistics['max_poops_cleaned'] = current_poops
-                self.brain_window.statistics_tab.update_display()
+            squid_statistics = getattr(self.squid, 'statistics', None)
+            if squid_statistics:
+                squid_statistics.max_poops_cleaned = max(
+                    squid_statistics.max_poops_cleaned,
+                    current_poops,
+                )
+                self.brain_window.statistics_tab.update_statistics()
 
     def track_rock_thrown(self):
         """Track when rock is thrown"""
@@ -1366,6 +1389,14 @@ class TamagotchiLogic:
         # 2. Paused?
         if self.simulation_speed == 0:
             return
+
+        # Record continuous model statistics once per simulation callback.
+        # The timer interval is explicit so accelerated timers and pauses do
+        # not turn a UI refresh cadence into the source of sleep duration.
+        squid_statistics = getattr(self.squid, 'statistics', None)
+        if squid_statistics:
+            elapsed_seconds = self.simulation_timer.interval() / 1000.0
+            squid_statistics.update(elapsed_seconds=elapsed_seconds)
         
         # Check for decorations message
         self._check_decorations_message()
@@ -1762,25 +1793,33 @@ class TamagotchiLogic:
         if random.random() < curious_chance:
             self.make_squid_curious()
 
-    def track_neuron_creation(self, neuron_type):
-        if hasattr(self.brain_window, 'statistics_tab'):
-            if neuron_type == 'novelty':
-                self.brain_window.statistics_tab.increment_stat('novelty_neurons_created')
-            elif neuron_type == 'stress':
-                self.brain_window.statistics_tab.increment_stat('stress_neurons_created')
-            elif neuron_type == 'reward':
-                self.brain_window.statistics_tab.increment_stat('reward_neurons_created')
+    def track_neuron_creation(self, neuron_type, current_count=None):
+        """Record one completed neurogenesis event on the canonical model."""
+        statistics = getattr(self.squid, 'statistics', None)
+        if not statistics:
+            return
 
-            current = self.brain_window.statistics_tab.statistics['current_neurons']
-            self.brain_window.statistics_tab.statistics['current_neurons'] = current + 1
-            self.brain_window.statistics_tab.update_display()
-            self.statistics_window.award(500)
+        statistics.record_neuron_birth(
+            neuron_type,
+            current_count=current_count,
+        )
+        statistics_tab = getattr(self.brain_window, 'statistics_tab', None)
+        if statistics_tab:
+            statistics_tab.update_statistics()
 
-    def track_neuron_counts(self, current_count, max_count):
-        """Track current and maximum neuron counts"""
-        if hasattr(self.brain_window, 'statistics_tab'):
-            self.brain_window.statistics_tab.update_current_neurons(current_count)
-            self.brain_window.statistics_tab.track_max_neurons(max_count)
+    def _observe_current_neuron_count(self):
+        """Record the live count after any post-birth pruning has settled."""
+        brain_widget = getattr(self.brain_window, 'brain_widget', None)
+        statistics = getattr(self.squid, 'statistics', None)
+        if not brain_widget or not statistics:
+            return
+
+        statistics.observe_neuron_count(
+            len(getattr(brain_widget, 'neuron_positions', {}))
+        )
+        statistics_tab = getattr(self.brain_window, 'statistics_tab', None)
+        if statistics_tab:
+            statistics_tab.update_statistics()
 
     def track_neurogenesis_triggers(self):
         """Update counters for neurogenesis triggers"""
@@ -2015,6 +2054,22 @@ class TamagotchiLogic:
         self.rps_game = RPSGame(self)
         self.rps_game.start_game()
 
+    def _set_sickness_state(self, is_sick):
+        """Keep squid state, mental-state visuals, and transition stats aligned."""
+        if self.squid is None:
+            return
+
+        is_sick = bool(is_sick)
+        self.squid.is_sick = is_sick
+
+        mental_state_manager = getattr(self.squid, 'mental_state_manager', None)
+        if mental_state_manager:
+            mental_state_manager.set_state("sick", is_sick)
+
+        statistics = getattr(self.squid, 'statistics', None)
+        if statistics:
+            statistics.record_sickness_state(is_sick)
+
     def give_medicine(self):
         
         # Get plugin results
@@ -2031,8 +2086,7 @@ class TamagotchiLogic:
             self.squid.mental_state_manager.is_state_active('sick'))):
             
             print("Debug: Applying medicine effects")
-            self.squid.is_sick = False
-            self.squid.mental_state_manager.set_state("sick", False)
+            self._set_sickness_state(False)
             
             self.squid.happiness = max(0, self.squid.happiness - 30)
             self.squid.sleepiness = min(100, self.squid.sleepiness + 50)
@@ -2221,9 +2275,9 @@ class TamagotchiLogic:
                     (self.hunger_threshold_time >= 10 * self.simulation_speed and
                     self.hunger_threshold_time <= 50 * self.simulation_speed)):
                     if random.random() < 0.8:
-                        self.squid.mental_state_manager.set_state("sick", True)
+                        self._set_sickness_state(True)
                 else:
-                    self.squid.mental_state_manager.set_state("sick", False)
+                    self._set_sickness_state(False)
 
                 # New logic for health decrease based on happiness and cleanliness
                 if self.squid.happiness < 20 and self.squid.cleanliness < 20:
@@ -2644,7 +2698,7 @@ class TamagotchiLogic:
         self.squid.cleanliness = 100
         self.squid.is_sleeping = False
         self.squid.health = 100
-        self.squid.is_sick = False
+        self._set_sickness_state(False)
 
         # Reset new neurons
         self.squid.satisfaction = 50
@@ -2745,6 +2799,11 @@ class TamagotchiLogic:
                 except ValueError:
                     pass
 
+            # Restore the canonical statistics model after squid state so an
+            # already-active sickness episode is resumed rather than recounted.
+            self.squid.statistics.load_statistics(data.get('statistics', {}))
+            self._set_sickness_state(getattr(self.squid, 'is_sick', False))
+
             # Load custom brain (Logic patched to load output bindings)
             custom_brain_data = data.get('custom_brain', {})
             custom_brain_loaded = False
@@ -2836,50 +2895,8 @@ class TamagotchiLogic:
             'name': getattr(self.squid, 'name', 'Squid'),  # Save squid name if it exists
         }
 
-        # Collect statistics as separate file
-        # Primary source: brain_window.statistics_tab (where gameplay updates go)
-        # Fallback: squid.statistics (legacy)
-        tab_stats = {}
-        if hasattr(self, 'brain_window') and hasattr(self.brain_window, 'statistics_tab'):
-            tab_stats = getattr(self.brain_window.statistics_tab, 'statistics', {})
-
-        squid_stats = self.squid.statistics
-
-        # Save using exact keys from StatisticsTab
-        statistics_data = {
-            # Age tracking
-            'total_age_seconds': squid_stats.get_total_age_seconds(),
-            'squid_age_minutes': tab_stats.get('squid_age_minutes', 0),
-
-            # Movement
-            'distance_swam': tab_stats.get('distance_swam', 0),
-
-            # Food consumption
-            'cheese_eaten': tab_stats.get('cheese_eaten', 0),
-            'sushi_eaten': tab_stats.get('sushi_eaten', 0),
-
-            # Poop tracking
-            'poops_created': tab_stats.get('poops_created', 0),
-            'max_poops_cleaned': tab_stats.get('max_poops_cleaned', 0),
-
-            # Interactions
-            'startles_experienced': tab_stats.get('startles_experienced', 0),
-            'ink_clouds_created': tab_stats.get('ink_clouds_created', 0),
-            'times_colour_changed': tab_stats.get('times_colour_changed', 0),
-            'rocks_thrown': tab_stats.get('rocks_thrown', 0),
-            'plants_interacted': tab_stats.get('plants_interacted', 0),
-
-            # Health/Sleep
-            'total_sleep_time': tab_stats.get('total_sleep_time', 0),
-            'sickness_episodes': tab_stats.get('sickness_episodes', 0),
-
-            # Neurogenesis
-            'novelty_neurons_created': tab_stats.get('novelty_neurons_created', 0),
-            'stress_neurons_created': tab_stats.get('stress_neurons_created', 0),
-            'reward_neurons_created': tab_stats.get('reward_neurons_created', 0),
-            'max_neurons_reached': tab_stats.get('max_neurons_reached', 0),
-            'current_neurons': tab_stats.get('current_neurons', 7),
-        }
+        # Statistics are owned by the model. The tab is a read-only projection.
+        statistics_data = self.squid.statistics.to_dict()
 
         # Collect tamagotchi logic state
         tamagotchi_logic_data = {
@@ -3019,6 +3036,8 @@ class TamagotchiLogic:
             squid_data = game_state['squid']
             
             self.squid.load_state(squid_data)
+            self.squid.statistics.load_statistics(save_data.get('statistics', {}))
+            self._set_sickness_state(getattr(self.squid, 'is_sick', False))
             
             # Load custom brain
             custom_brain_data = save_data.get('custom_brain')
@@ -3034,38 +3053,6 @@ class TamagotchiLogic:
             self.squid.memory_manager.short_term_memory = save_data.get('ShortTerm', [])
             self.squid.memory_manager.long_term_memory = save_data.get('LongTerm', [])
 
-            # Sync neurogenesis neuron counts with actual brain state
-            if hasattr(self.brain_window, 'brain_widget') and hasattr(self.brain_window.brain_widget, 'enhanced_neurogenesis'):
-                eng = self.brain_window.brain_widget.enhanced_neurogenesis
-                if hasattr(eng, 'functional_neurons'):
-                    # Count neurons by specialization type
-                    novelty_count = 0
-                    stress_count = 0
-                    reward_count = 0
-                    
-                    for neuron in eng.functional_neurons.values():
-                        if hasattr(neuron, 'specialization'):
-                            if neuron.specialization == 'novelty':
-                                novelty_count += 1
-                            elif neuron.specialization == 'stress':
-                                stress_count += 1
-                            elif neuron.specialization == 'reward':
-                                reward_count += 1
-                    
-                    # Update statistics tab with ground truth values
-                    if hasattr(self.brain_window, 'statistics_tab') and hasattr(self.brain_window.statistics_tab, 'statistics'):
-                        self.brain_window.statistics_tab.statistics['novelty_neurons_created'] = novelty_count
-                        self.brain_window.statistics_tab.statistics['stress_neurons_created'] = stress_count
-                        self.brain_window.statistics_tab.statistics['reward_neurons_created'] = reward_count
-                        self.brain_window.statistics_tab.update_display()
-                        print(f"✓ Synced neuron counts: {novelty_count} novelty, {stress_count} stress, {reward_count} reward")
-                    
-                    # Also sync with squid's internal statistics for consistency
-                    if hasattr(self, 'squid') and hasattr(self.squid, 'statistics'):
-                        self.squid.statistics.novelty_neurons_created = novelty_count
-                        self.squid.statistics.stress_neurons_created = stress_count
-                        self.squid.statistics.reward_neurons_created = reward_count
-            
             # Load decorations
             decorations_data = game_state.get('decorations', [])
             self.user_interface.load_decorations_data(decorations_data)

--- a/src/tamagotchi_logic.py
+++ b/src/tamagotchi_logic.py
@@ -1147,8 +1147,7 @@ class TamagotchiLogic:
             self.squid.current_speed = 180
             self.squid.direction = random.choice(['up', 'down', 'left', 'right'])
 
-            # A startle is one event whether or not it produces an ink cloud.
-            self._maybe_create_startle_ink_cloud(source)
+            # Record the accepted startle once on the model.
             self.track_startle()
 
             # --- resilience / anxiety / ink logic --------------------------
@@ -1293,19 +1292,6 @@ class TamagotchiLogic:
         
         # Backup timer to force remove after 10 seconds in case animation fails
         QtCore.QTimer.singleShot(10000, lambda: self.force_remove_ink_cloud(ink_cloud_item))
-
-    def _maybe_create_startle_ink_cloud(self, source):
-        """Create and finish one startle ink response when its roll succeeds."""
-        if source == "startled_awake" or random.random() >= 0.25:
-            return False
-
-        self.create_ink_cloud()
-        self.squid.status = "fleeing!"
-        self.squid.memory_manager.add_short_term_memory(
-            'behaviour', 'ink_cloud', 'Startled! Created an ink cloud'
-        )
-        QtCore.QTimer.singleShot(5000, self.squid.end_ink_flee)
-        return True
 
     def force_remove_ink_cloud(self, ink_cloud_item):
         """Force remove the ink cloud if it still exists after timeout"""

--- a/src/tamagotchi_logic.py
+++ b/src/tamagotchi_logic.py
@@ -352,38 +352,65 @@ class TamagotchiLogic:
         
 
     def update_squid_age(self):
-        if hasattr(self.brain_window, 'statistics_tab'):
-            age_min = int((time.time() - self.squid_birth_time) / 60)
-            self.brain_window.statistics_tab.statistics['squid_age_minutes'] = age_min
-            self.brain_window.statistics_tab.update_display()
+        """Refresh the age projection from the persistent model clock."""
+        self._refresh_statistics_tab()
+
+    def _refresh_statistics_tab(self):
+        """Refresh the optional statistics projection without owning data."""
+        brain_window = getattr(self, 'brain_window', None)
+        statistics_tab = getattr(brain_window, 'statistics_tab', None)
+        if statistics_tab:
+            statistics_tab.update_statistics()
+
+    def record_statistic_event(self, event_name, amount=1):
+        """Record one discrete event on the model, then refresh the view."""
+        statistics = getattr(getattr(self, 'squid', None), 'statistics', None)
+        if not statistics or not statistics.increment(event_name, amount):
+            return False
+
+        self._refresh_statistics_tab()
+        return True
+
+    def track_distance(self, distance):
+        """Record movement on the model, then refresh the optional view."""
+        statistics = getattr(getattr(self, 'squid', None), 'statistics', None)
+        if not statistics:
+            return
+
+        statistics.add_distance(distance)
+        self._refresh_statistics_tab()
 
 
     def track_poop_thrown(self):
-        if hasattr(self.brain_window, 'statistics_tab'):
-            self.brain_window.statistics_tab.increment_stat('poops_thrown')
+        self.record_statistic_event('poops_thrown')
 
     def update_highest_anxiety(self, value):
-        if hasattr(self.brain_window, 'statistics_tab'):
-            tab = self.brain_window.statistics_tab
-            if value > tab.statistics['highest_anxiety']:
-                tab.statistics['highest_anxiety'] = value
-                tab.update_display()
+        statistics = getattr(getattr(self, 'squid', None), 'statistics', None)
+        if statistics:
+            statistics.highest_anxiety = max(
+                statistics.highest_anxiety,
+                value,
+            )
+            self._refresh_statistics_tab()
 
     def update_lowest_happiness(self, value):
-        if hasattr(self.brain_window, 'statistics_tab'):
-            tab = self.brain_window.statistics_tab
-            if value < tab.statistics['lowest_happiness']:
-                tab.statistics['lowest_happiness'] = value
-                tab.update_display()
+        statistics = getattr(getattr(self, 'squid', None), 'statistics', None)
+        if statistics:
+            statistics.lowest_happiness = min(
+                statistics.lowest_happiness,
+                value,
+            )
+            self._refresh_statistics_tab()
 
     def update_max_memories(self):
-        if hasattr(self.brain_window, 'statistics_tab') and hasattr(self.squid, 'memory_manager'):
-            tab = self.brain_window.statistics_tab
-            stm = len(self.squid.memory_manager.short_term_memory)
-            ltm = len(self.squid.memory_manager.long_term_memory)
-            tab.statistics['max_short_term_memories'] = max(tab.statistics['max_short_term_memories'], stm)
-            tab.statistics['max_long_term_memories'] = max(tab.statistics['max_long_term_memories'], ltm)
-            tab.update_display()
+        statistics = getattr(getattr(self, 'squid', None), 'statistics', None)
+        memory_manager = getattr(getattr(self, 'squid', None), 'memory_manager', None)
+        if statistics and memory_manager:
+            statistics.observe_memory_counts(
+                len(memory_manager.short_term_memory),
+                len(memory_manager.long_term_memory),
+            )
+            self._refresh_statistics_tab()
 
     
 
@@ -1281,13 +1308,7 @@ class TamagotchiLogic:
         fade_out_animation.start()
         self.statistics_window.award(-250)
 
-        # Record the event once on the canonical model.
-        if hasattr(self, 'squid') and hasattr(self.squid, 'statistics'):
-            self.squid.statistics.increment('ink_clouds_created')
-        
-        # Refresh the read-only statistics projection.
-        if hasattr(self.brain_window, 'statistics_tab'):
-            self.brain_window.statistics_tab.update_statistics()
+        self.record_statistic_event('ink_clouds_created')
         
         
         # Backup timer to force remove after 10 seconds in case animation fails
@@ -1324,45 +1345,38 @@ class TamagotchiLogic:
 
     def track_food_consumed(self, food_item):
         """Track when food is consumed"""
-        if hasattr(self.brain_window, 'statistics_tab'):
-            if getattr(food_item, 'is_sushi', False):
-                self.brain_window.statistics_tab.increment_stat('sushi_eaten')
-            else:
-                self.brain_window.statistics_tab.increment_stat('cheese_eaten')
+        event_name = (
+            'sushi_eaten'
+            if getattr(food_item, 'is_sushi', False)
+            else 'cheese_eaten'
+        )
+        self.record_statistic_event(event_name)
 
     def track_poop_created(self):
         """Track when poop is created"""
-        if hasattr(self.brain_window, 'statistics_tab'):
-            self.brain_window.statistics_tab.increment_stat('poops_created')
-            # Update max poops if needed
-            current_poops = len(self.poop_items)
-            squid_statistics = getattr(self.squid, 'statistics', None)
-            if squid_statistics:
-                squid_statistics.max_poops_cleaned = max(
-                    squid_statistics.max_poops_cleaned,
-                    current_poops,
-                )
-                self.brain_window.statistics_tab.update_statistics()
+        statistics = getattr(getattr(self, 'squid', None), 'statistics', None)
+        if not statistics:
+            return
+
+        statistics.increment('poops_created')
+        statistics.observe_poop_count(len(self.poop_items))
+        self._refresh_statistics_tab()
 
     def track_rock_thrown(self):
         """Track when rock is thrown"""
-        if hasattr(self.brain_window, 'statistics_tab'):
-            self.brain_window.statistics_tab.increment_stat('rocks_thrown')
+        self.record_statistic_event('rocks_thrown')
 
     def track_plant_interaction(self):
         """Track when squid interacts with plants"""
-        if hasattr(self.brain_window, 'statistics_tab'):
-            self.brain_window.statistics_tab.increment_stat('plants_interacted')
+        self.record_statistic_event('plants_interacted')
+
+    def track_colour_changed(self):
+        """Track a completed squid colour change."""
+        self.record_statistic_event('times_colour_changed')
 
     def track_startle(self):
         """Track when squid is startled"""
-        statistics = getattr(self.squid, 'statistics', None)
-        if statistics:
-            statistics.increment('startles_experienced')
-
-        statistics_tab = getattr(self.brain_window, 'statistics_tab', None)
-        if statistics_tab:
-            statistics_tab.update_statistics()
+        self.record_statistic_event('startles_experienced')
 
 
             ######################################### UPDATE_SIMULATION METHOD BELOW

--- a/src/tamagotchi_logic.py
+++ b/src/tamagotchi_logic.py
@@ -254,7 +254,7 @@ class TamagotchiLogic:
         # Connect neurogenesis signal to show icon and store long-term memory
         if hasattr(self.brain_window, 'brain_widget'):
             self.brain_window.brain_widget.neuronCreated.connect(self._on_neurogenesis_icon_and_memory)
-            self._observe_current_neuron_count()
+            self.refresh_neuron_count()
 
     def handle_vision_update(self, result):
         """Cache the latest vision result and push to brain immediately."""
@@ -272,7 +272,7 @@ class TamagotchiLogic:
         current_count = None
 
         if brain_widget:
-            current_count = len(getattr(brain_widget, 'neuron_positions', {}))
+            current_count = self._live_neuron_count()
             neurogenesis = getattr(brain_widget, 'enhanced_neurogenesis', None)
             functional_neurons = getattr(neurogenesis, 'functional_neurons', {})
             functional_neuron = functional_neurons.get(neuron_name)
@@ -289,7 +289,7 @@ class TamagotchiLogic:
         # The creation signal is emitted before optional pruning. Re-observe
         # the settled live count on the next event-loop turn without reducing
         # the lifetime maximum recorded at birth.
-        QtCore.QTimer.singleShot(0, self._observe_current_neuron_count)
+        QtCore.QTimer.singleShot(0, self.refresh_neuron_count)
 
         # Show the ng icon above the squid's head for 4 seconds
         if hasattr(self.squid, 'show_neurogenesis_icon'):
@@ -1147,21 +1147,9 @@ class TamagotchiLogic:
             self.squid.current_speed = 180
             self.squid.direction = random.choice(['up', 'down', 'left', 'right'])
 
-            # ------------------------------------------------------------------
-            # NEW: 15 % ink-cloud trigger (skip if woken from sleep)
-            # ------------------------------------------------------------------
-            if source != "startled_awake" and random.random() < 0.25:
-                self.create_ink_cloud()
-            
-            # Track startle in statistics (was only in else block)
-            if hasattr(self.brain_window, 'statistics_tab'):
-                self.brain_window.statistics_tab.increment_stat('startles_experienced')
-                
-                self.squid.status = "fleeing!"
-                self.squid.memory_manager.add_short_term_memory(
-                    'behaviour', 'ink_cloud', 'Startled! Created an ink cloud'
-                )
-                QtCore.QTimer.singleShot(5000, self.squid.end_ink_flee)
+            # A startle is one event whether or not it produces an ink cloud.
+            self._maybe_create_startle_ink_cloud(source)
+            self.track_startle()
 
             # --- resilience / anxiety / ink logic --------------------------
             stress_neuron_count = 0
@@ -1306,6 +1294,19 @@ class TamagotchiLogic:
         # Backup timer to force remove after 10 seconds in case animation fails
         QtCore.QTimer.singleShot(10000, lambda: self.force_remove_ink_cloud(ink_cloud_item))
 
+    def _maybe_create_startle_ink_cloud(self, source):
+        """Create and finish one startle ink response when its roll succeeds."""
+        if source == "startled_awake" or random.random() >= 0.25:
+            return False
+
+        self.create_ink_cloud()
+        self.squid.status = "fleeing!"
+        self.squid.memory_manager.add_short_term_memory(
+            'behaviour', 'ink_cloud', 'Startled! Created an ink cloud'
+        )
+        QtCore.QTimer.singleShot(5000, self.squid.end_ink_flee)
+        return True
+
     def force_remove_ink_cloud(self, ink_cloud_item):
         """Force remove the ink cloud if it still exists after timeout"""
         if ink_cloud_item in self.squid.ui.scene.items():
@@ -1369,8 +1370,13 @@ class TamagotchiLogic:
 
     def track_startle(self):
         """Track when squid is startled"""
-        if hasattr(self.brain_window, 'statistics_tab'):
-            self.brain_window.statistics_tab.increment_stat('startles_experienced')
+        statistics = getattr(self.squid, 'statistics', None)
+        if statistics:
+            statistics.increment('startles_experienced')
+
+        statistics_tab = getattr(self.brain_window, 'statistics_tab', None)
+        if statistics_tab:
+            statistics_tab.update_statistics()
 
 
             ######################################### UPDATE_SIMULATION METHOD BELOW
@@ -1392,11 +1398,13 @@ class TamagotchiLogic:
             return
 
         # Record continuous model statistics once per simulation callback.
-        # The timer interval is explicit so accelerated timers and pauses do
-        # not turn a UI refresh cadence into the source of sleep duration.
+        # Sleep duration is elapsed wall-clock time, matching the former
+        # time.time()-based statistic. The timer already fires more often at
+        # higher simulation speeds, so multiplying by simulation_speed would
+        # overcount the time the squid was actually asleep.
         squid_statistics = getattr(self.squid, 'statistics', None)
         if squid_statistics:
-            elapsed_seconds = self.simulation_timer.interval() / 1000.0
+            elapsed_seconds = self._statistics_elapsed_seconds()
             squid_statistics.update(elapsed_seconds=elapsed_seconds)
         
         # Check for decorations message
@@ -1797,27 +1805,42 @@ class TamagotchiLogic:
     def track_neuron_creation(self, neuron_type, current_count):
         """Record one completed neurogenesis event on the canonical model."""
         statistics = getattr(self.squid, 'statistics', None)
-        if not statistics:
-            return
+        if statistics:
+            statistics.record_neuron_birth(
+                neuron_type,
+                current_count=current_count,
+            )
 
-        statistics.record_neuron_birth(
-            neuron_type,
-            current_count=current_count,
-        )
+        statistics_window = getattr(self, 'statistics_window', None)
+        if statistics_window:
+            statistics_window.add_score_for_neuron_creation()
+
         statistics_tab = getattr(self.brain_window, 'statistics_tab', None)
         if statistics_tab:
             statistics_tab.update_statistics()
 
-    def _observe_current_neuron_count(self):
+    def _statistics_elapsed_seconds(self):
+        """Return wall-clock seconds represented by one simulation callback."""
+        return self.simulation_timer.interval() / 1000.0
+
+    def _live_neuron_count(self):
+        """Count positioned network neurons, excluding only matching keys."""
+        brain_widget = getattr(self.brain_window, 'brain_widget', None)
+        if not brain_widget:
+            return 0
+
+        positions = getattr(brain_widget, 'neuron_positions', {})
+        excluded = set(getattr(brain_widget, 'excluded_neurons', ()) or ())
+        return sum(name not in excluded for name in positions)
+
+    def refresh_neuron_count(self):
         """Record the live count after any post-birth pruning has settled."""
         brain_widget = getattr(self.brain_window, 'brain_widget', None)
         statistics = getattr(self.squid, 'statistics', None)
         if not brain_widget or not statistics:
             return
 
-        statistics.observe_neuron_count(
-            len(getattr(brain_widget, 'neuron_positions', {}))
-        )
+        statistics.observe_neuron_count(self._live_neuron_count())
         statistics_tab = getattr(self.brain_window, 'statistics_tab', None)
         if statistics_tab:
             statistics_tab.update_statistics()
@@ -2824,7 +2847,7 @@ class TamagotchiLogic:
             brain_state = data.get('brain_state', {})
             if brain_state and hasattr(self, 'brain_window'):
                 self.brain_window.set_brain_state(brain_state)
-                self._observe_current_neuron_count()
+                self.refresh_neuron_count()
                 
                 # Manually load bindings if not using custom brain
                 # This handles standard saves where bindings are stored in 'brain_state'
@@ -3049,7 +3072,7 @@ class TamagotchiLogic:
             # Load brain state
             brain_state = save_data.get('brain_state', {})
             self.brain_window.set_brain_state(brain_state)
-            self._observe_current_neuron_count()
+            self.refresh_neuron_count()
             
             # Load memories
             self.squid.memory_manager.short_term_memory = save_data.get('ShortTerm', [])

--- a/src/tamagotchi_logic.py
+++ b/src/tamagotchi_logic.py
@@ -254,6 +254,7 @@ class TamagotchiLogic:
         # Connect neurogenesis signal to show icon and store long-term memory
         if hasattr(self.brain_window, 'brain_widget'):
             self.brain_window.brain_widget.neuronCreated.connect(self._on_neurogenesis_icon_and_memory)
+            self._observe_current_neuron_count()
 
     def handle_vision_update(self, result):
         """Cache the latest vision result and push to brain immediately."""
@@ -1793,7 +1794,7 @@ class TamagotchiLogic:
         if random.random() < curious_chance:
             self.make_squid_curious()
 
-    def track_neuron_creation(self, neuron_type, current_count=None):
+    def track_neuron_creation(self, neuron_type, current_count):
         """Record one completed neurogenesis event on the canonical model."""
         statistics = getattr(self.squid, 'statistics', None)
         if not statistics:
@@ -2276,8 +2277,7 @@ class TamagotchiLogic:
                     self.hunger_threshold_time <= 50 * self.simulation_speed)):
                     if random.random() < 0.8:
                         self._set_sickness_state(True)
-                else:
-                    self._set_sickness_state(False)
+                # Sickness persists until medicine or an explicit game reset.
 
                 # New logic for health decrease based on happiness and cleanliness
                 if self.squid.happiness < 20 and self.squid.cleanliness < 20:
@@ -2824,6 +2824,7 @@ class TamagotchiLogic:
             brain_state = data.get('brain_state', {})
             if brain_state and hasattr(self, 'brain_window'):
                 self.brain_window.set_brain_state(brain_state)
+                self._observe_current_neuron_count()
                 
                 # Manually load bindings if not using custom brain
                 # This handles standard saves where bindings are stored in 'brain_state'
@@ -3048,6 +3049,7 @@ class TamagotchiLogic:
             # Load brain state
             brain_state = save_data.get('brain_state', {})
             self.brain_window.set_brain_state(brain_state)
+            self._observe_current_neuron_count()
             
             # Load memories
             self.squid.memory_manager.short_term_memory = save_data.get('ShortTerm', [])

--- a/tests/test_squid_statistics.py
+++ b/tests/test_squid_statistics.py
@@ -67,6 +67,16 @@ class SquidStatisticsTests(unittest.TestCase):
         self.assertEqual(self.statistics.max_neurons_reached, 12)
         self.assertEqual(self.statistics.reward_neurons_created, 1)
 
+    def test_other_lifetime_maxima_never_decrease(self):
+        self.statistics.observe_poop_count(5)
+        self.statistics.observe_poop_count(2)
+        self.statistics.observe_memory_counts(3, 7)
+        self.statistics.observe_memory_counts(1, 4)
+
+        self.assertEqual(self.statistics.max_poops_cleaned, 5)
+        self.assertEqual(self.statistics.max_short_term_memories, 3)
+        self.assertEqual(self.statistics.max_long_term_memories, 7)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_squid_statistics.py
+++ b/tests/test_squid_statistics.py
@@ -1,6 +1,6 @@
 import unittest
 
-from src.squid_statistics import SquidStatistics
+from src.squid_statistics import DEFAULT_NEURON_COUNT, SquidStatistics
 
 
 class FakeSquid:
@@ -16,6 +16,14 @@ class SquidStatisticsTests(unittest.TestCase):
     def setUp(self):
         self.squid = FakeSquid()
         self.statistics = SquidStatistics(self.squid)
+
+    def test_default_neuron_count_matches_the_standard_brain(self):
+        self.assertEqual(DEFAULT_NEURON_COUNT, 8)
+        self.assertEqual(self.statistics.current_neurons, DEFAULT_NEURON_COUNT)
+        self.assertEqual(
+            self.statistics.max_neurons_reached,
+            DEFAULT_NEURON_COUNT,
+        )
 
     def test_sleep_time_uses_explicit_elapsed_time(self):
         self.squid.is_sleeping = True

--- a/tests/test_squid_statistics.py
+++ b/tests/test_squid_statistics.py
@@ -67,6 +67,17 @@ class SquidStatisticsTests(unittest.TestCase):
         self.assertEqual(self.statistics.max_neurons_reached, 12)
         self.assertEqual(self.statistics.reward_neurons_created, 1)
 
+    def test_reset_preserves_current_and_lifetime_neuron_counts(self):
+        self.statistics.observe_neuron_count(12)
+        self.statistics.observe_neuron_count(9)
+        self.statistics.cheese_consumed = 3
+
+        self.statistics.reset()
+
+        self.assertEqual(self.statistics.current_neurons, 9)
+        self.assertEqual(self.statistics.max_neurons_reached, 12)
+        self.assertEqual(self.statistics.cheese_consumed, 0)
+
     def test_other_lifetime_maxima_never_decrease(self):
         self.statistics.observe_poop_count(5)
         self.statistics.observe_poop_count(2)

--- a/tests/test_squid_statistics.py
+++ b/tests/test_squid_statistics.py
@@ -1,0 +1,64 @@
+import unittest
+
+from src.squid_statistics import SquidStatistics
+
+
+class FakeSquid:
+    def __init__(self):
+        self.anxiety = 10
+        self.happiness = 90
+        self.satisfaction = 20
+        self.is_sleeping = False
+        self.is_sick = False
+
+
+class SquidStatisticsTests(unittest.TestCase):
+    def setUp(self):
+        self.squid = FakeSquid()
+        self.statistics = SquidStatistics(self.squid)
+
+    def test_sleep_time_uses_explicit_elapsed_time(self):
+        self.squid.is_sleeping = True
+        self.statistics.update(elapsed_seconds=2.5)
+
+        self.squid.is_sleeping = False
+        self.statistics.update(elapsed_seconds=10)
+
+        self.squid.is_sleeping = True
+        self.statistics.update(elapsed_seconds=0.25)
+
+        self.assertEqual(self.statistics.time_spent_asleep, 2.75)
+
+    def test_sickness_counts_only_false_to_true_transitions(self):
+        self.statistics.record_sickness_state(False)
+        self.statistics.record_sickness_state(True)
+        self.statistics.record_sickness_state(True)
+        self.statistics.record_sickness_state(False)
+        self.statistics.record_sickness_state(False)
+        self.statistics.record_sickness_state(True)
+
+        self.assertEqual(self.statistics.sickness_episodes, 2)
+
+    def test_neuron_birth_updates_type_and_lifetime_maximum_once(self):
+        self.statistics.record_neuron_birth("novelty", current_count=8)
+        self.statistics.record_neuron_birth("stress", current_count=9)
+        self.statistics.record_neuron_birth("connector", current_count=10)
+
+        self.assertEqual(self.statistics.novelty_neurons_created, 1)
+        self.assertEqual(self.statistics.stress_neurons_created, 1)
+        self.assertEqual(self.statistics.reward_neurons_created, 0)
+        self.assertEqual(self.statistics.current_neurons, 10)
+        self.assertEqual(self.statistics.max_neurons_reached, 10)
+
+    def test_lifetime_maximum_never_decreases_with_current_count(self):
+        self.statistics.observe_neuron_count(12)
+        self.statistics.observe_neuron_count(8)
+        self.statistics.record_neuron_birth("reward", current_count=9)
+
+        self.assertEqual(self.statistics.current_neurons, 9)
+        self.assertEqual(self.statistics.max_neurons_reached, 12)
+        self.assertEqual(self.statistics.reward_neurons_created, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_statistics_event_wiring.py
+++ b/tests/test_statistics_event_wiring.py
@@ -1,0 +1,192 @@
+import io
+import unittest
+from contextlib import redirect_stdout
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from src.brain_widget import BrainWidget
+from src.neurogenesis import EnhancedNeurogenesis
+from src.squid_statistics import SquidStatistics
+from src.tamagotchi_logic import TamagotchiLogic
+
+
+class RecordingSignal:
+    def __init__(self):
+        self.events = []
+
+    def emit(self, neuron_name):
+        self.events.append(neuron_name)
+
+
+class NotifyingNeurogenesis:
+    def __init__(self, brain_widget, neuron_name):
+        self.brain_widget = brain_widget
+        self.neuron_name = neuron_name
+
+    def capture_experience_context(self, **_kwargs):
+        return object()
+
+    def should_create_neuron(self, _context):
+        return True
+
+    def create_functional_neuron(self, _context, **_kwargs):
+        EnhancedNeurogenesis._notify_neuron_created(self, self.neuron_name)
+        return self.neuron_name
+
+
+class FakeSquid:
+    def __init__(self):
+        self.anxiety = 10
+        self.happiness = 90
+        self.satisfaction = 20
+        self.is_sleeping = False
+        self.is_sick = False
+        self.statistics = SquidStatistics(self)
+
+
+class RecordingMentalStateManager:
+    def __init__(self):
+        self.states = []
+
+    def set_state(self, state_name, is_active):
+        self.states.append((state_name, is_active))
+
+
+class StatisticsEventWiringTests(unittest.TestCase):
+    def test_threaded_completion_does_not_duplicate_engine_notification(self):
+        signal = RecordingSignal()
+        controller = SimpleNamespace(
+            _pending_neurogenesis_check=True,
+            neuronCreated=signal,
+            pruning_enabled=False,
+            update=lambda: None,
+        )
+        controller.enhanced_neurogenesis = NotifyingNeurogenesis(
+            controller,
+            "novelty_threaded",
+        )
+
+        with redirect_stdout(io.StringIO()):
+            BrainWidget._on_neurogenesis_complete(
+                controller,
+                {
+                    "should_create": True,
+                    "neuron_type": "novelty",
+                    "state_context": {},
+                },
+            )
+
+        self.assertEqual(signal.events, ["novelty_threaded"])
+
+    def test_synchronous_fallback_does_not_delegate_an_already_created_birth(self):
+        signal = RecordingSignal()
+        delegated_results = []
+
+        def create_synchronously(_state):
+            signal.emit("stress_synchronous")
+            return {"should_create": True}
+
+        controller = SimpleNamespace(
+            _pending_neurogenesis_check=False,
+            enhanced_neurogenesis=SimpleNamespace(),
+            state={},
+            _use_threaded_processing=False,
+            check_neurogenesis_triggers=create_synchronously,
+            _on_neurogenesis_complete=delegated_results.append,
+        )
+
+        BrainWidget._periodic_neurogenesis_check(controller)
+
+        self.assertEqual(signal.events, ["stress_synchronous"])
+        self.assertEqual(delegated_results, [])
+        self.assertFalse(controller._pending_neurogenesis_check)
+
+    def test_orphan_rescue_emits_one_completed_birth(self):
+        signal = RecordingSignal()
+        brain_widget = SimpleNamespace(
+            neuronCreated=signal,
+            neuron_positions={
+                "orphan": (100, 100),
+                "hunger": (300, 300),
+            },
+            state={
+                "orphan": 50.0,
+                "hunger": 50.0,
+            },
+            excluded_neurons=[],
+            weights={},
+            visible_neurons=set(),
+            neuron_shapes={},
+            state_colors={},
+            log_neurogenesis_event=lambda *_args, **_kwargs: None,
+        )
+        neurogenesis = object.__new__(EnhancedNeurogenesis)
+        neurogenesis.brain_widget = brain_widget
+        neurogenesis.functional_neurons = {}
+
+        with (
+            redirect_stdout(io.StringIO()),
+            patch("src.neurogenesis.random.randint", return_value=0),
+            patch("src.neurogenesis.random.uniform", return_value=0.5),
+            patch("src.neurogenesis.random.random", return_value=0.75),
+        ):
+            neurogenesis.rescue_orphan("orphan")
+
+        self.assertEqual(signal.events, ["connector_rescue"])
+
+    def test_one_birth_signal_updates_the_model_once_without_the_tab(self):
+        squid = FakeSquid()
+        neuron_name = "reward_test"
+        brain_widget = SimpleNamespace(
+            neuron_positions={f"neuron_{index}": (0, 0) for index in range(9)},
+            enhanced_neurogenesis=SimpleNamespace(
+                functional_neurons={
+                    neuron_name: SimpleNamespace(neuron_type="reward"),
+                }
+            ),
+            neurogenesis_data={},
+        )
+        logic = object.__new__(TamagotchiLogic)
+        logic.squid = squid
+        logic.brain_window = SimpleNamespace(
+            brain_widget=brain_widget,
+            statistics_tab=None,
+        )
+
+        with patch("src.tamagotchi_logic.QtCore.QTimer.singleShot") as single_shot:
+            logic._on_neurogenesis_icon_and_memory(neuron_name)
+
+        self.assertEqual(squid.statistics.reward_neurons_created, 1)
+        self.assertEqual(squid.statistics.current_neurons, 9)
+        self.assertEqual(squid.statistics.max_neurons_reached, 9)
+        single_shot.assert_called_once_with(
+            0,
+            logic._observe_current_neuron_count,
+        )
+
+    def test_sickness_funnel_keeps_state_and_transition_count_aligned(self):
+        squid = FakeSquid()
+        squid.mental_state_manager = RecordingMentalStateManager()
+        logic = object.__new__(TamagotchiLogic)
+        logic.squid = squid
+
+        logic._set_sickness_state(True)
+        logic._set_sickness_state(True)
+        logic._set_sickness_state(False)
+        logic._set_sickness_state(True)
+
+        self.assertTrue(squid.is_sick)
+        self.assertEqual(squid.statistics.sickness_episodes, 2)
+        self.assertEqual(
+            squid.mental_state_manager.states,
+            [
+                ("sick", True),
+                ("sick", True),
+                ("sick", False),
+                ("sick", True),
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_statistics_event_wiring.py
+++ b/tests/test_statistics_event_wiring.py
@@ -213,44 +213,65 @@ class StatisticsEventWiringTests(unittest.TestCase):
                 )
                 self.assertAlmostEqual(elapsed, 1.0, places=2)
 
-    def test_startle_ink_followup_runs_only_when_cloud_is_created(self):
-        memory_manager = SimpleNamespace(
-            add_short_term_memory=Mock(),
+    def test_one_startle_creates_at_most_one_ink_cloud(self):
+        cases = (
+            ("first startle", "environment", False, 0.0, 1),
+            ("later successful roll", "environment", True, 0.0, 1),
+            ("later failed roll", "environment", True, 0.99, 0),
+            ("awakened later successful roll", "startled_awake", True, 0.0, 1),
         )
-        squid = SimpleNamespace(
-            status="startled",
-            memory_manager=memory_manager,
-            end_ink_flee=Mock(),
-        )
-        logic = object.__new__(TamagotchiLogic)
-        logic.squid = squid
-        logic.create_ink_cloud = Mock()
 
-        with (
-            patch("src.tamagotchi_logic.random.random", return_value=0.5),
-            patch("src.tamagotchi_logic.QtCore.QTimer.singleShot") as single_shot,
-        ):
-            self.assertFalse(logic._maybe_create_startle_ink_cloud("environment"))
+        for name, source, already_startled, ink_roll, expected_clouds in cases:
+            with self.subTest(name=name):
+                squid = FakeSquid()
+                squid.status = "roaming"
+                squid.is_fleeing = False
+                squid.personality = None
+                squid.mental_state_manager = RecordingMentalStateManager()
+                squid.memory_manager = SimpleNamespace(
+                    add_short_term_memory=Mock(),
+                )
 
-        logic.create_ink_cloud.assert_not_called()
-        memory_manager.add_short_term_memory.assert_not_called()
-        single_shot.assert_not_called()
-        self.assertEqual(squid.status, "startled")
+                logic = object.__new__(TamagotchiLogic)
+                logic.mental_states_enabled = True
+                logic.initial_startle_allowed = True
+                logic.startle_cooldown_max = 10
+                logic.squid = squid
+                logic.statistics_window = SimpleNamespace(award=Mock())
+                logic.brain_window = SimpleNamespace(
+                    brain_widget=SimpleNamespace(
+                        get_stress_neuron_count=lambda: 0,
+                    ),
+                    statistics_tab=None,
+                )
+                logic.create_ink_cloud = Mock()
+                logic.show_message = Mock()
 
-        with (
-            patch("src.tamagotchi_logic.random.random", return_value=0.1),
-            patch("src.tamagotchi_logic.QtCore.QTimer.singleShot") as single_shot,
-        ):
-            self.assertTrue(logic._maybe_create_startle_ink_cloud("environment"))
+                if already_startled:
+                    logic._has_startled_before = True
 
-        logic.create_ink_cloud.assert_called_once_with()
-        memory_manager.add_short_term_memory.assert_called_once_with(
-            'behaviour',
-            'ink_cloud',
-            'Startled! Created an ink cloud',
-        )
-        single_shot.assert_called_once_with(5000, squid.end_ink_flee)
-        self.assertEqual(squid.status, "fleeing!")
+                with (
+                    patch(
+                        "src.tamagotchi_logic.random.random",
+                        return_value=ink_roll,
+                    ),
+                    patch(
+                        "src.tamagotchi_logic.random.choice",
+                        return_value="right",
+                    ),
+                    patch(
+                        "src.tamagotchi_logic.QtCore.QTimer.singleShot"
+                    ) as single_shot,
+                ):
+                    logic.startle_squid(source)
+
+                self.assertEqual(
+                    logic.create_ink_cloud.call_count,
+                    expected_clouds,
+                )
+                self.assertEqual(squid.statistics.startles_experienced, 1)
+                squid.memory_manager.add_short_term_memory.assert_called_once()
+                self.assertEqual(single_shot.call_count, 1)
 
     def test_startle_count_does_not_depend_on_statistics_tab(self):
         squid = FakeSquid()

--- a/tests/test_statistics_event_wiring.py
+++ b/tests/test_statistics_event_wiring.py
@@ -4,8 +4,12 @@ from contextlib import redirect_stdout
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
+from src.brain_about_tab import AboutTab
 from src.brain_widget import BrainWidget
+from src.interactions import RockInteractionManager
+from src.interactions2 import PoopInteractionManager
 from src.neurogenesis import EnhancedNeurogenesis
+from src.squid import Squid
 from src.squid_statistics import SquidStatistics
 from src.tamagotchi_logic import TamagotchiLogic
 
@@ -282,6 +286,268 @@ class StatisticsEventWiringTests(unittest.TestCase):
         logic.track_startle()
 
         self.assertEqual(squid.statistics.startles_experienced, 1)
+
+    def test_discrete_events_do_not_depend_on_statistics_tab(self):
+        squid = FakeSquid()
+        logic = object.__new__(TamagotchiLogic)
+        logic.squid = squid
+        logic.brain_window = SimpleNamespace(statistics_tab=None)
+        logic.poop_items = [object(), object(), object()]
+
+        logic.track_food_consumed(SimpleNamespace(is_sushi=True))
+        logic.track_food_consumed(SimpleNamespace(is_sushi=False))
+        logic.track_poop_created()
+        logic.track_poop_thrown()
+        logic.track_rock_thrown()
+        logic.track_plant_interaction()
+        logic.track_colour_changed()
+        logic.track_distance(80)
+
+        self.assertEqual(squid.statistics.sushi_consumed, 1)
+        self.assertEqual(squid.statistics.cheese_consumed, 1)
+        self.assertEqual(squid.statistics.poops_created, 1)
+        self.assertEqual(squid.statistics.max_poops_cleaned, 3)
+        self.assertEqual(squid.statistics.total_poops_thrown, 1)
+        self.assertEqual(squid.statistics.total_rocks_thrown, 1)
+        self.assertEqual(squid.statistics.plants_interacted, 1)
+        self.assertEqual(squid.statistics.times_colour_changed, 1)
+        self.assertEqual(squid.statistics.distance_swam, 80)
+
+    def test_real_ink_cloud_path_is_safe_without_statistics_tab(self):
+        squid = FakeSquid()
+        squid.squid_x = 0
+        squid.squid_y = 0
+        squid.squid_width = 20
+        squid.squid_height = 20
+        squid.ui = SimpleNamespace(
+            scene=SimpleNamespace(addItem=Mock()),
+        )
+
+        logic = object.__new__(TamagotchiLogic)
+        logic.squid = squid
+        logic.brain_window = SimpleNamespace(statistics_tab=None)
+        logic.statistics_window = SimpleNamespace(award=Mock())
+
+        pixmap = Mock()
+        pixmap.width.return_value = 10
+        pixmap.height.return_value = 10
+        ink_cloud_item = Mock()
+        opacity_effect = Mock()
+        animation = Mock()
+
+        with (
+            patch(
+                "src.tamagotchi_logic.QtGui.QPixmap",
+                return_value=pixmap,
+            ),
+            patch(
+                "src.tamagotchi_logic.QtWidgets.QGraphicsPixmapItem",
+                return_value=ink_cloud_item,
+            ),
+            patch(
+                "src.tamagotchi_logic.QtWidgets.QGraphicsOpacityEffect",
+                return_value=opacity_effect,
+            ),
+            patch(
+                "src.tamagotchi_logic.QtCore.QPropertyAnimation",
+                return_value=animation,
+            ),
+            patch(
+                "src.tamagotchi_logic.QtCore.QTimer.singleShot"
+            ) as single_shot,
+        ):
+            logic.create_ink_cloud()
+
+        self.assertEqual(squid.statistics.ink_clouds_created, 1)
+        logic.statistics_window.award.assert_called_once_with(-250)
+        squid.ui.scene.addItem.assert_called_once_with(ink_cloud_item)
+        single_shot.assert_called_once()
+        self.assertEqual(single_shot.call_args.args[0], 10000)
+
+    def test_legacy_peak_memory_and_age_updates_are_model_owned(self):
+        squid = FakeSquid()
+        squid.memory_manager = SimpleNamespace(
+            short_term_memory=[1, 2, 3],
+            long_term_memory=[1, 2, 3, 4],
+        )
+        logic = object.__new__(TamagotchiLogic)
+        logic.squid = squid
+        logic.brain_window = SimpleNamespace(statistics_tab=None)
+
+        logic.update_squid_age()
+        logic.update_highest_anxiety(75)
+        logic.update_highest_anxiety(50)
+        logic.update_lowest_happiness(20)
+        logic.update_lowest_happiness(40)
+        logic.update_max_memories()
+
+        squid.memory_manager.short_term_memory.clear()
+        squid.memory_manager.long_term_memory.clear()
+        logic.update_max_memories()
+
+        persisted = squid.statistics.to_dict()
+        self.assertEqual(persisted["highest_anxiety"], 75)
+        self.assertEqual(persisted["lowest_happiness"], 20)
+        self.assertEqual(persisted["max_short_term_memories"], 3)
+        self.assertEqual(persisted["max_long_term_memories"], 4)
+
+    def test_rock_throw_delivers_one_model_event(self):
+        squid = FakeSquid()
+        rock_rect = SimpleNamespace(
+            width=lambda: 2,
+            height=lambda: 4,
+        )
+        rock = SimpleNamespace(
+            filename="rock.png",
+            setParentItem=Mock(),
+            boundingRect=lambda: rock_rect,
+            setPos=Mock(),
+            setVisible=Mock(),
+        )
+        squid.carried_rock = rock
+        squid.status = "roaming"
+        squid.happiness = 50
+        squid.satisfaction = 50
+        squid.anxiety = 50
+        squid.squid_item = SimpleNamespace(
+            sceneBoundingRect=lambda: SimpleNamespace(
+                center=lambda: SimpleNamespace(
+                    x=lambda: 10,
+                    y=lambda: 20,
+                )
+            )
+        )
+        squid.memory_manager = SimpleNamespace(
+            add_short_term_memory=Mock(),
+        )
+
+        statistics_tab = SimpleNamespace(
+            increment_stat=lambda name, amount=1: squid.statistics.increment(
+                name,
+                amount,
+            ),
+            update_statistics=Mock(),
+        )
+        logic = object.__new__(TamagotchiLogic)
+        logic.squid = squid
+        logic.brain_window = SimpleNamespace(statistics_tab=statistics_tab)
+        logic.statistics_window = SimpleNamespace(award=Mock())
+
+        manager = object.__new__(RockInteractionManager)
+        manager.squid = squid
+        manager.logic = logic
+        manager.rock_config = {
+            "happiness_boost": 5,
+            "satisfaction_boost": 3,
+            "anxiety_reduction": 2,
+        }
+        manager.throw_animation_timer = Mock()
+        manager.throw_animation_timer.isActive.return_value = False
+        manager.multiplayer_plugin = None
+
+        self.assertTrue(manager.throw_rock())
+        self.assertEqual(squid.statistics.total_rocks_thrown, 1)
+        statistics_tab.update_statistics.assert_called_once_with()
+
+    def test_poop_throw_delivers_one_model_event(self):
+        squid = FakeSquid()
+        poop_rect = SimpleNamespace(
+            width=lambda: 2,
+            height=lambda: 4,
+        )
+        poop = SimpleNamespace(
+            filename="poop.png",
+            setParentItem=Mock(),
+            boundingRect=lambda: poop_rect,
+            setPos=Mock(),
+            setVisible=Mock(),
+        )
+        squid.carried_poop = poop
+        squid.status = "roaming"
+        squid.happiness = 50
+        squid.satisfaction = 50
+        squid.anxiety = 50
+        squid.squid_item = SimpleNamespace(
+            sceneBoundingRect=lambda: SimpleNamespace(
+                center=lambda: SimpleNamespace(
+                    x=lambda: 10,
+                    y=lambda: 20,
+                )
+            )
+        )
+        squid.memory_manager = SimpleNamespace(
+            add_short_term_memory=Mock(),
+        )
+
+        statistics_tab = SimpleNamespace(update_statistics=Mock())
+        logic = object.__new__(TamagotchiLogic)
+        logic.squid = squid
+        logic.brain_window = SimpleNamespace(statistics_tab=statistics_tab)
+        logic.statistics_window = SimpleNamespace(award=Mock())
+
+        manager = object.__new__(PoopInteractionManager)
+        manager.squid = squid
+        manager.logic = logic
+        manager.poop_config = {}
+        manager.throw_animation_timer = Mock()
+        manager.throw_animation_timer.isActive.return_value = False
+        manager.multiplayer_plugin = None
+
+        self.assertTrue(manager.throw_poop())
+        self.assertEqual(squid.statistics.total_poops_thrown, 1)
+        statistics_tab.update_statistics.assert_called_once_with()
+
+    def test_plant_completion_delivers_one_model_event(self):
+        squid = FakeSquid()
+        squid.curiosity = 10
+        squid.memory_manager = SimpleNamespace(
+            add_short_term_memory=Mock(),
+            add_long_term_memory=Mock(),
+            plant_interaction_count={},
+        )
+        squid.push_animation = object()
+
+        statistics_tab = SimpleNamespace(
+            increment_stat=Mock(),
+            update_statistics=Mock(),
+        )
+        logic = object.__new__(TamagotchiLogic)
+        logic.squid = squid
+        logic.brain_window = SimpleNamespace(statistics_tab=statistics_tab)
+        logic.recent_positive_outcome = False
+        logic.show_message = Mock()
+        squid.tamagotchi_logic = logic
+
+        Squid._on_push_complete(
+            squid,
+            SimpleNamespace(category="plant", filename="fern.png"),
+        )
+        Squid._on_push_complete(
+            squid,
+            SimpleNamespace(category="rock", filename="rock.png"),
+        )
+
+        self.assertEqual(squid.statistics.plants_interacted, 1)
+        statistics_tab.increment_stat.assert_not_called()
+        statistics_tab.update_statistics.assert_called_once_with()
+
+    def test_colour_change_delivers_one_model_event_without_tab(self):
+        squid = FakeSquid()
+        squid.apply_tint = Mock()
+        logic = object.__new__(TamagotchiLogic)
+        logic.squid = squid
+        logic.brain_window = SimpleNamespace(statistics_tab=None)
+        controller = SimpleNamespace(tamagotchi_logic=logic)
+        colour = SimpleNamespace(isValid=lambda: True)
+
+        with patch(
+            "src.brain_about_tab.QtWidgets.QColorDialog.getColor",
+            return_value=colour,
+        ):
+            AboutTab.open_color_picker(controller)
+
+        squid.apply_tint.assert_called_once_with(colour)
+        self.assertEqual(squid.statistics.times_colour_changed, 1)
 
     def test_sickness_funnel_keeps_state_and_transition_count_aligned(self):
         squid = FakeSquid()

--- a/tests/test_statistics_event_wiring.py
+++ b/tests/test_statistics_event_wiring.py
@@ -2,7 +2,7 @@ import io
 import unittest
 from contextlib import redirect_stdout
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from src.brain_widget import BrainWidget
 from src.neurogenesis import EnhancedNeurogenesis
@@ -138,7 +138,17 @@ class StatisticsEventWiringTests(unittest.TestCase):
         squid = FakeSquid()
         neuron_name = "reward_test"
         brain_widget = SimpleNamespace(
-            neuron_positions={f"neuron_{index}": (0, 0) for index in range(9)},
+            neuron_positions={
+                **{f"neuron_{index}": (0, 0) for index in range(9)},
+                "is_sick": (0, 0),
+            },
+            excluded_neurons=[
+                "is_sick",
+                "is_eating",
+                "pursuing_food",
+                "direction",
+                "is_sleeping",
+            ],
             enhanced_neurogenesis=SimpleNamespace(
                 functional_neurons={
                     neuron_name: SimpleNamespace(neuron_type="reward"),
@@ -152,6 +162,9 @@ class StatisticsEventWiringTests(unittest.TestCase):
             brain_widget=brain_widget,
             statistics_tab=None,
         )
+        logic.statistics_window = SimpleNamespace(
+            add_score_for_neuron_creation=Mock(),
+        )
 
         with patch("src.tamagotchi_logic.QtCore.QTimer.singleShot") as single_shot:
             logic._on_neurogenesis_icon_and_memory(neuron_name)
@@ -159,10 +172,95 @@ class StatisticsEventWiringTests(unittest.TestCase):
         self.assertEqual(squid.statistics.reward_neurons_created, 1)
         self.assertEqual(squid.statistics.current_neurons, 9)
         self.assertEqual(squid.statistics.max_neurons_reached, 9)
+        logic.statistics_window.add_score_for_neuron_creation.assert_called_once_with()
         single_shot.assert_called_once_with(
             0,
-            logic._observe_current_neuron_count,
+            logic.refresh_neuron_count,
         )
+
+    def test_live_neuron_count_filters_only_excluded_position_keys(self):
+        logic = object.__new__(TamagotchiLogic)
+        logic.brain_window = SimpleNamespace(
+            brain_widget=SimpleNamespace(
+                neuron_positions={
+                    **{f"core_{index}": (0, 0) for index in range(8)},
+                    "is_sick": (0, 0),
+                },
+                excluded_neurons=[
+                    "is_sick",
+                    "is_eating",
+                    "pursuing_food",
+                    "direction",
+                    "is_sleeping",
+                ],
+            )
+        )
+
+        self.assertEqual(logic._live_neuron_count(), 8)
+
+    def test_sleep_elapsed_time_stays_wall_clock_at_faster_speeds(self):
+        logic = object.__new__(TamagotchiLogic)
+
+        for speed in (1, 2, 3):
+            with self.subTest(speed=speed):
+                interval_ms = 1000 // speed
+                logic.simulation_timer = SimpleNamespace(
+                    interval=lambda value=interval_ms: value
+                )
+                elapsed = sum(
+                    logic._statistics_elapsed_seconds()
+                    for _ in range(speed)
+                )
+                self.assertAlmostEqual(elapsed, 1.0, places=2)
+
+    def test_startle_ink_followup_runs_only_when_cloud_is_created(self):
+        memory_manager = SimpleNamespace(
+            add_short_term_memory=Mock(),
+        )
+        squid = SimpleNamespace(
+            status="startled",
+            memory_manager=memory_manager,
+            end_ink_flee=Mock(),
+        )
+        logic = object.__new__(TamagotchiLogic)
+        logic.squid = squid
+        logic.create_ink_cloud = Mock()
+
+        with (
+            patch("src.tamagotchi_logic.random.random", return_value=0.5),
+            patch("src.tamagotchi_logic.QtCore.QTimer.singleShot") as single_shot,
+        ):
+            self.assertFalse(logic._maybe_create_startle_ink_cloud("environment"))
+
+        logic.create_ink_cloud.assert_not_called()
+        memory_manager.add_short_term_memory.assert_not_called()
+        single_shot.assert_not_called()
+        self.assertEqual(squid.status, "startled")
+
+        with (
+            patch("src.tamagotchi_logic.random.random", return_value=0.1),
+            patch("src.tamagotchi_logic.QtCore.QTimer.singleShot") as single_shot,
+        ):
+            self.assertTrue(logic._maybe_create_startle_ink_cloud("environment"))
+
+        logic.create_ink_cloud.assert_called_once_with()
+        memory_manager.add_short_term_memory.assert_called_once_with(
+            'behaviour',
+            'ink_cloud',
+            'Startled! Created an ink cloud',
+        )
+        single_shot.assert_called_once_with(5000, squid.end_ink_flee)
+        self.assertEqual(squid.status, "fleeing!")
+
+    def test_startle_count_does_not_depend_on_statistics_tab(self):
+        squid = FakeSquid()
+        logic = object.__new__(TamagotchiLogic)
+        logic.squid = squid
+        logic.brain_window = SimpleNamespace(statistics_tab=None)
+
+        logic.track_startle()
+
+        self.assertEqual(squid.statistics.startles_experienced, 1)
 
     def test_sickness_funnel_keeps_state_and_transition_count_aligned(self):
         squid = FakeSquid()

--- a/tests/test_statistics_persistence.py
+++ b/tests/test_statistics_persistence.py
@@ -75,6 +75,19 @@ class StatisticsPersistenceTests(unittest.TestCase):
                 self.assertEqual(restored.max_neurons_reached, 11)
                 self.assertEqual(restored.novelty_neurons_created, 2)
 
+    def test_load_preserves_a_lifetime_maximum_above_current_count(self):
+        restored = SquidStatistics(FakeSquid())
+
+        restored.load_statistics(
+            {
+                "current_neurons": 8,
+                "max_neurons_reached": 15,
+            }
+        )
+
+        self.assertEqual(restored.current_neurons, 8)
+        self.assertEqual(restored.max_neurons_reached, 15)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_statistics_persistence.py
+++ b/tests/test_statistics_persistence.py
@@ -88,6 +88,34 @@ class StatisticsPersistenceTests(unittest.TestCase):
         self.assertEqual(restored.current_neurons, 8)
         self.assertEqual(restored.max_neurons_reached, 15)
 
+    def test_reset_neuron_counts_survive_save_archive_round_trip(self):
+        statistics = SquidStatistics(FakeSquid())
+        statistics.observe_neuron_count(12)
+        statistics.observe_neuron_count(9)
+        statistics.reset()
+
+        with tempfile.TemporaryDirectory() as save_directory:
+            manager = SaveManager(save_directory)
+            with redirect_stdout(io.StringIO()):
+                archive_path = manager.save_game(
+                    {
+                        "game_state": {
+                            "squid": {
+                                "uuid": "00000000-0000-0000-0000-000000000026",
+                            }
+                        },
+                        "statistics": statistics.to_dict(),
+                    }
+                )
+            self.assertIsNotNone(archive_path)
+            loaded_archive = manager.load_game()
+
+        restored = SquidStatistics(FakeSquid())
+        restored.load_statistics(loaded_archive["statistics"])
+
+        self.assertEqual(restored.current_neurons, 9)
+        self.assertEqual(restored.max_neurons_reached, 12)
+
     def test_every_canonical_persistence_key_round_trips(self):
         statistics = SquidStatistics(FakeSquid())
         expected_attributes = {}

--- a/tests/test_statistics_persistence.py
+++ b/tests/test_statistics_persistence.py
@@ -88,6 +88,27 @@ class StatisticsPersistenceTests(unittest.TestCase):
         self.assertEqual(restored.current_neurons, 8)
         self.assertEqual(restored.max_neurons_reached, 15)
 
+    def test_every_canonical_persistence_key_round_trips(self):
+        statistics = SquidStatistics(FakeSquid())
+        expected_attributes = {}
+        for index, attribute_name in enumerate(
+            statistics._PERSISTENCE_KEYS.values(),
+            start=1,
+        ):
+            value = index + 0.25
+            setattr(statistics, attribute_name, value)
+            expected_attributes[attribute_name] = value
+
+        restored = SquidStatistics(FakeSquid())
+        restored.load_statistics(statistics.to_dict())
+
+        for attribute_name, expected_value in expected_attributes.items():
+            with self.subTest(attribute_name=attribute_name):
+                self.assertEqual(
+                    getattr(restored, attribute_name),
+                    expected_value,
+                )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_statistics_persistence.py
+++ b/tests/test_statistics_persistence.py
@@ -1,0 +1,80 @@
+import io
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+
+from src.save_manager import SaveManager
+from src.squid_statistics import SquidStatistics
+
+
+class FakeSquid:
+    def __init__(self, *, is_sick=False):
+        self.anxiety = 10
+        self.happiness = 90
+        self.satisfaction = 20
+        self.is_sleeping = False
+        self.is_sick = is_sick
+
+
+class StatisticsPersistenceTests(unittest.TestCase):
+    def test_statistics_survive_save_archive_round_trip(self):
+        squid = FakeSquid()
+        statistics = SquidStatistics(squid)
+        squid.is_sleeping = True
+        statistics.update(elapsed_seconds=12.5)
+        statistics.record_sickness_state(True)
+        statistics.record_sickness_state(True)
+        statistics.record_neuron_birth("novelty", current_count=8)
+        statistics.record_neuron_birth("reward", current_count=9)
+        statistics.observe_neuron_count(8)
+
+        with tempfile.TemporaryDirectory() as save_directory:
+            manager = SaveManager(save_directory)
+            with redirect_stdout(io.StringIO()):
+                archive_path = manager.save_game(
+                    {
+                        "game_state": {
+                            "squid": {
+                                "uuid": "00000000-0000-0000-0000-000000000026",
+                            }
+                        },
+                        "statistics": statistics.to_dict(),
+                    }
+                )
+            self.assertIsNotNone(archive_path)
+            loaded_archive = manager.load_game()
+
+        restored_squid = FakeSquid(is_sick=True)
+        restored = SquidStatistics(restored_squid)
+        restored.load_statistics(loaded_archive["statistics"])
+
+        self.assertEqual(restored.time_spent_asleep, 12.5)
+        self.assertEqual(restored.sickness_episodes, 1)
+        self.assertEqual(restored.novelty_neurons_created, 1)
+        self.assertEqual(restored.reward_neurons_created, 1)
+        self.assertEqual(restored.current_neurons, 8)
+        self.assertEqual(restored.max_neurons_reached, 9)
+
+        restored.record_sickness_state(True)
+        self.assertEqual(restored.sickness_episodes, 1)
+
+    def test_legacy_current_count_repairs_an_invalid_lifetime_maximum(self):
+        for saved_maximum in (None, 0, 5):
+            with self.subTest(saved_maximum=saved_maximum):
+                restored = SquidStatistics(FakeSquid())
+                saved_statistics = {
+                    "current_neurons": 11,
+                    "novelty_neurons_created": 2,
+                }
+                if saved_maximum is not None:
+                    saved_statistics["max_neurons_reached"] = saved_maximum
+
+                restored.load_statistics(saved_statistics)
+
+                self.assertEqual(restored.current_neurons, 11)
+                self.assertEqual(restored.max_neurons_reached, 11)
+                self.assertEqual(restored.novelty_neurons_created, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- make `SquidStatistics` the canonical source and persist it directly
- count sleep from elapsed simulation callbacks and sickness only on false-to-true transitions
- emit completed neurogenesis births once across threaded, synchronous, and orphan-rescue paths
- record each accepted startle and resulting ink cloud at most once
- route food, poop, rock, plant, colour, and distance events through the model even when the statistics tab is absent
- preserve current and lifetime neuron counts through pruning, loading, and statistics resets
- preserve lifetime poop and memory maxima and derive age from the persistent model clock
- keep the statistics tab as a read-only projection of the model

## Testing

- `python -m unittest discover -s tests -v` (28 passed)
- `python android/tests/test_engine.py` (7/7 passed)
- `python -m compileall -q src main.py tests`

Closes #26


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Statistics now sync from the canonical statistics model when the tab becomes visible, with improved model-driven reporting for distance, sleep timing, sickness, and neuron/life counters.
* **Bug Fixes**
  * Fixed neuron creation notification behavior to avoid duplicates/missing signals, and aligned ink-cloud/startle, interaction counters, and rock/poop/plant event tracking.
  * Corrected reset/save/load so current and lifetime neuron counts (and related maxima) stay consistent; updated “Max Neurons” export fallback.
* **Tests**
  * Expanded wiring, persistence, and reset regression coverage for tab/no-tab and lifetime maxima invariants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
