### PR TITLE
Claude/failed build release apk xnv4pv

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -114,6 +114,16 @@ jobs:
           P4A_RELEASE_KEYALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
           P4A_RELEASE_KEYALIAS_PASSWD: ${{ secrets.ANDROID_KEY_PASSWORD }}
         run: |
+          # When the signing secrets aren't configured, the P4A_RELEASE_* env
+          # vars above are still *set* by GitHub Actions, just to empty
+          # strings. python-for-android's generated build.gradle only checks
+          # these for non-null (not non-blank), so a present-but-empty
+          # P4A_RELEASE_KEYSTORE makes it try `file('')` and fail with
+          # "Cannot convert '' to File." Unset them here so buildozer falls
+          # back to producing an unsigned release APK instead.
+          if [ -z "$P4A_RELEASE_KEYSTORE" ]; then
+            unset P4A_RELEASE_KEYSTORE P4A_RELEASE_KEYSTORE_PASSWD P4A_RELEASE_KEYALIAS P4A_RELEASE_KEYALIAS_PASSWD
+          fi
           set -o pipefail
           for attempt in 1 2 3; do
             echo "::group::buildozer attempt $attempt"

--- a/android/buildozer.spec
+++ b/android/buildozer.spec
@@ -47,6 +47,11 @@ android.minapi = 24
 android.archs = arm64-v8a
 android.allow_backup = True
 
+# Buildozer defaults release builds to an Android App Bundle (.aab), which
+# the release workflow doesn't look for (and isn't directly installable).
+# Force a plain, installable .apk instead.
+android.release_artifact = apk
+
 # SDL2 bootstrap is what Kivy uses.
 p4a.bootstrap = sdl2
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release builds now produce installable APK files instead of app bundles.

* **Bug Fixes**
  * Improved release build handling when signing credentials are blank, allowing unsigned APKs to be generated without signing-related failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->