### PR TITLE
Restore statistics tracking with verified Qt lifecycle

### DIFF
--- a/src/brain_about_tab.py
+++ b/src/brain_about_tab.py
@@ -256,9 +256,8 @@ class AboutTab(BrainBaseTab):
         if color.isValid():
             if self.tamagotchi_logic and self.tamagotchi_logic.squid:
                 self.tamagotchi_logic.squid.apply_tint(color)
-                if hasattr(self.tamagotchi_logic, 'brain_window') and \
-                hasattr(self.tamagotchi_logic.brain_window, 'statistics_tab'):
-                    self.tamagotchi_logic.brain_window.statistics_tab.increment_stat('times_colour_changed')
+                if hasattr(self.tamagotchi_logic, 'track_colour_changed'):
+                    self.tamagotchi_logic.track_colour_changed()
 
     def edit_name(self):
         """Allow user to edit squid name on double-click"""

--- a/src/brain_statistics_tab.py
+++ b/src/brain_statistics_tab.py
@@ -2,6 +2,7 @@ from PyQt5 import QtCore, QtGui, QtWidgets
 from .brain_base_tab import BrainBaseTab
 from .display_scaling import DisplayScaling
 from .localisation import Localisation
+from .squid_statistics import DEFAULT_NEURON_COUNT
 import time
 
 class StatisticsTab(BrainBaseTab):
@@ -26,7 +27,7 @@ class StatisticsTab(BrainBaseTab):
             'novelty_neurons_created': 0,
             'stress_neurons_created': 0,
             'reward_neurons_created': 0,
-            'current_neurons': 7,
+            'current_neurons': DEFAULT_NEURON_COUNT,
             'squid_age_minutes': 0,
             'last_position': None,
             'last_update_time': time.time()
@@ -244,7 +245,7 @@ class StatisticsTab(BrainBaseTab):
                 squid_stats = getattr(self.tamagotchi_logic.squid, 'statistics', None)
                 if squid_stats:
                     squid_stats.reset()
-                    self.tamagotchi_logic._observe_current_neuron_count()
+                    self.tamagotchi_logic.refresh_neuron_count()
                     self._sync_from_squid_statistics()
                     self.update_display()
 
@@ -276,7 +277,10 @@ class StatisticsTab(BrainBaseTab):
                     f.write(f"{loc.get('stat_sleep')}: {int(self.statistics['total_sleep_time'])}\n")
                     f.write(f"{loc.get('stat_sickness')}: {self.statistics['sickness_episodes']}\n")
                     f.write(f"{loc.get('stat_squid_age')}: {int(self.statistics['squid_age_minutes'])}\n")
-                    f.write(f"Max Neurons: {self.statistics.get('current_neurons', 7)}\n")
+                    f.write(
+                        "Max Neurons: "
+                        f"{self.statistics.get('current_neurons', DEFAULT_NEURON_COUNT)}\n"
+                    )
                     f.write("\n" + "=" * 30 + "\n")
                     f.write(f"{loc.get('export_end')}\n")
 

--- a/src/brain_statistics_tab.py
+++ b/src/brain_statistics_tab.py
@@ -55,11 +55,15 @@ class StatisticsTab(BrainBaseTab):
         super().hideEvent(event)
         self.is_visible = False
 
-    def set_logic(self, logic):
-        """Called by main window after TamagotchiLogic (and squid) exist."""
-        self.tamagotchi_logic = logic
+    def set_tamagotchi_logic(self, tamagotchi_logic):
+        """Attach late-created game logic and immediately refresh the view."""
+        super().set_tamagotchi_logic(tamagotchi_logic)
         self._sync_from_squid_statistics()
         self.update_display()
+
+    def set_logic(self, logic):
+        """Retain the legacy setter as an alias for external callers."""
+        self.set_tamagotchi_logic(logic)
 
     def _sync_from_squid_statistics(self):
         """Mirror the persistent squid statistics object into the tab state."""

--- a/src/brain_statistics_tab.py
+++ b/src/brain_statistics_tab.py
@@ -41,21 +41,13 @@ class StatisticsTab(BrainBaseTab):
         self.update_timer.start(1000)  # Update every second
 
         self.is_visible = False
-        self.pending_distance = 0  # Store distance when tab not visible
-
-        # Connect to neuron creation events for real-time updates
-        if self.brain_widget and hasattr(self.brain_widget, 'neuronCreated'):
-            self.brain_widget.neuronCreated.connect(self._on_neuron_created_update_stats)
 
     def showEvent(self, event):
         """Called when tab becomes visible"""
         super().showEvent(event)
         self.is_visible = True
-        # Apply any pending distance
-        if self.pending_distance > 0:
-            self.statistics['distance_swam'] += self.pending_distance
-            self.pending_distance = 0
-            self.update_display()
+        self._sync_from_squid_statistics()
+        self.update_display()
 
     def hideEvent(self, event):
         """Called when tab becomes hidden"""
@@ -65,6 +57,8 @@ class StatisticsTab(BrainBaseTab):
     def set_logic(self, logic):
         """Called by main window after TamagotchiLogic (and squid) exist."""
         self.tamagotchi_logic = logic
+        self._sync_from_squid_statistics()
+        self.update_display()
 
     def _sync_from_squid_statistics(self):
         """Mirror the persistent squid statistics object into the tab state."""
@@ -103,58 +97,17 @@ class StatisticsTab(BrainBaseTab):
         if not squid_stats:
             return False
 
-        attr_map = {
-            'cheese_eaten': 'cheese_consumed',
-            'sushi_eaten': 'sushi_consumed',
-            'poops_created': 'poops_created',
-            'poops_thrown': 'total_poops_thrown',
-            'max_poops_cleaned': 'max_poops_cleaned',
-            'startles_experienced': 'startles_experienced',
-            'ink_clouds_created': 'ink_clouds_created',
-            'times_colour_changed': 'times_colour_changed',
-            'rocks_thrown': 'total_rocks_thrown',
-            'plants_interacted': 'plants_interacted',
-            'novelty_neurons_created': 'novelty_neurons_created',
-            'stress_neurons_created': 'stress_neurons_created',
-            'reward_neurons_created': 'reward_neurons_created',
-        }
-
-        attr_name = attr_map.get(stat_name)
-        if not attr_name or not hasattr(squid_stats, attr_name):
-            return False
-
-        current_value = getattr(squid_stats, attr_name, 0)
-        setattr(squid_stats, attr_name, current_value + amount)
-        return True
-
-    def update_current_neurons(self, count):
-        """Update the current neuron count in the UI, enforcing only-count-up logic.
-        
-        This ensures the max neurons stat only ever increases, never decreases.
-        """
-        if hasattr(self, 'stat_labels') and 'current_neurons' in self.stat_labels:
-            current_max = self.statistics.get('current_neurons', 0)
-            if count > current_max:
-                self.statistics['current_neurons'] = count
-                self.stat_labels['current_neurons'].setText(str(count))
-
-                if self.tamagotchi_logic and hasattr(self.tamagotchi_logic, 'squid'):
-                    squid = self.tamagotchi_logic.squid
-                    if hasattr(squid, 'statistics') and hasattr(squid.statistics, 'max_neurons_reached'):
-                        squid.statistics.max_neurons_reached = count
-                        squid.statistics.current_neurons = count
-
-    def _on_neuron_created_update_stats(self, neuron_name: str):
-        """Update current neuron count when a new neuron is created"""
-        self.update_statistics()
+        return squid_stats.increment(stat_name, amount)
 
     def track_distance(self, distance):
-        """Track distance swam - only updates if tab is visible"""
-        if self.is_visible:
-            self.statistics['distance_swam'] += distance
-            self.update_display()
-        else:
-            self.pending_distance += distance
+        """Forward a movement event to the canonical model."""
+        if self.tamagotchi_logic and getattr(self.tamagotchi_logic, 'squid', None):
+            squid_stats = getattr(self.tamagotchi_logic.squid, 'statistics', None)
+            if squid_stats:
+                squid_stats.add_distance(distance)
+                self._sync_from_squid_statistics()
+                if self.is_visible:
+                    self.update_display()
 
     def initialize_ui(self):
         """Build the statistics tab interface with DPI scaling"""
@@ -234,52 +187,17 @@ class StatisticsTab(BrainBaseTab):
         self.layout.addStretch()
 
     def update_from_brain_state(self, state):
-        """Update tab based on brain state"""
+        """Refresh the read-only mirror after a brain-state update."""
         if not self.tamagotchi_logic or not self.tamagotchi_logic.squid:
             return
 
-        squid = self.tamagotchi_logic.squid
-
-        current_pos = (squid.squid_x, squid.squid_y)
-        if self.statistics['last_position'] is not None:
-            last_pos = self.statistics['last_position']
-            distance = ((current_pos[0] - last_pos[0])**2 + (current_pos[1] - last_pos[1])**2)**0.5
-            self.statistics['distance_swam'] += distance
-
-        self.statistics['last_position'] = current_pos
-
-        if squid.is_sleeping:
-            current_time = time.time()
-            time_elapsed = current_time - self.statistics['last_update_time']
-            self.statistics['total_sleep_time'] += time_elapsed
-
-        self.statistics['last_update_time'] = time.time()
         self._sync_from_squid_statistics()
         self.update_display()
 
     def update_statistics(self):
-        """Update statistics from squid state"""
+        """Refresh the UI from the canonical squid statistics model."""
         if not self.tamagotchi_logic or not self.tamagotchi_logic.squid:
             return
-
-        squid = self.tamagotchi_logic.squid
-
-        if not self.brain_widget:
-            parent = self.parent()
-            if hasattr(parent, 'brain_widget'):
-                self.brain_widget = parent.brain_widget
-
-        if self.brain_widget and hasattr(self.brain_widget, 'neuron_positions'):
-            real_current_count = len(self.brain_widget.neuron_positions)
-            stored_count = self.statistics.get('current_neurons', 0)
-
-            if real_current_count > stored_count:
-                self.statistics['current_neurons'] = real_current_count
-
-                if hasattr(squid, 'statistics') and hasattr(squid.statistics, 'max_neurons_reached'):
-                    if real_current_count > squid.statistics.max_neurons_reached:
-                        squid.statistics.max_neurons_reached = real_current_count
-                        squid.statistics.current_neurons = real_current_count
 
         self._sync_from_squid_statistics()
         self.statistics['last_update_time'] = time.time()
@@ -305,17 +223,12 @@ class StatisticsTab(BrainBaseTab):
                 label.setText(str(int(value)))
 
     def increment_stat(self, stat_name, amount=1):
-        """Increment a specific statistic"""
-        updated_canonical = self._increment_squid_stat(stat_name, amount)
-
-        if stat_name in self.statistics:
-            self.statistics[stat_name] += amount
-        elif not updated_canonical:
+        """Forward a discrete event to the canonical model."""
+        if not self._increment_squid_stat(stat_name, amount):
             return
 
         self._sync_from_squid_statistics()
         self.update_display()
-        self.save_statistics()
 
     def reset_statistics(self):
         """Reset all statistics to zero"""
@@ -327,12 +240,12 @@ class StatisticsTab(BrainBaseTab):
         )
 
         if reply == QtWidgets.QMessageBox.Yes:
-            for key in self.statistics:
-                if key not in ['last_position', 'last_update_time']:
-                    self.statistics[key] = 0
-            self.statistics['last_update_time'] = time.time()
-            self.update_display()
-            self.save_statistics()
+            if self.tamagotchi_logic and getattr(self.tamagotchi_logic, 'squid', None):
+                squid_stats = getattr(self.tamagotchi_logic.squid, 'statistics', None)
+                if squid_stats:
+                    squid_stats.reset()
+                    self._sync_from_squid_statistics()
+                    self.update_display()
 
     def export_statistics(self):
         """Export statistics to a file"""
@@ -377,19 +290,9 @@ class StatisticsTab(BrainBaseTab):
                 )
 
     def save_statistics(self):
-        """Save statistics to file"""
-        if hasattr(self.tamagotchi_logic, 'save_manager'):
-            try:
-                self.tamagotchi_logic.save_manager.save_statistics(self.statistics)
-            except:
-                pass
+        """Compatibility hook; the main save pipeline persists the model."""
+        self._sync_from_squid_statistics()
 
     def load_statistics(self):
-        """Load statistics from file"""
-        if hasattr(self.tamagotchi_logic, 'save_manager'):
-            try:
-                loaded_stats = self.tamagotchi_logic.save_manager.load_statistics()
-                if loaded_stats:
-                    self.statistics.update(loaded_stats)
-            except:
-                pass
+        """Compatibility hook; the main load pipeline restores the model."""
+        self._sync_from_squid_statistics()

--- a/src/brain_statistics_tab.py
+++ b/src/brain_statistics_tab.py
@@ -89,26 +89,11 @@ class StatisticsTab(BrainBaseTab):
         self.statistics['current_neurons'] = getattr(squid_stats, 'max_neurons_reached', self.statistics['current_neurons'])
         self.statistics['squid_age_minutes'] = int(getattr(squid_stats, 'get_total_age_seconds', lambda: 0)() // 60)
 
-    def _increment_squid_stat(self, stat_name, amount=1):
-        """Increment the canonical squid statistics attribute for a tab stat key."""
-        if not self.tamagotchi_logic or not getattr(self.tamagotchi_logic, 'squid', None):
-            return False
-
-        squid_stats = getattr(self.tamagotchi_logic.squid, 'statistics', None)
-        if not squid_stats:
-            return False
-
-        return squid_stats.increment(stat_name, amount)
-
     def track_distance(self, distance):
-        """Forward a movement event to the canonical model."""
-        if self.tamagotchi_logic and getattr(self.tamagotchi_logic, 'squid', None):
-            squid_stats = getattr(self.tamagotchi_logic.squid, 'statistics', None)
-            if squid_stats:
-                squid_stats.add_distance(distance)
-                self._sync_from_squid_statistics()
-                if self.is_visible:
-                    self.update_display()
+        """Compatibility bridge; movement ownership remains in the logic/model."""
+        logic = self.tamagotchi_logic
+        if logic and hasattr(logic, 'track_distance'):
+            logic.track_distance(distance)
 
     def initialize_ui(self):
         """Build the statistics tab interface with DPI scaling"""
@@ -224,12 +209,10 @@ class StatisticsTab(BrainBaseTab):
                 label.setText(str(int(value)))
 
     def increment_stat(self, stat_name, amount=1):
-        """Forward a discrete event to the canonical model."""
-        if not self._increment_squid_stat(stat_name, amount):
-            return
-
-        self._sync_from_squid_statistics()
-        self.update_display()
+        """Compatibility bridge; event ownership remains in the logic/model."""
+        logic = self.tamagotchi_logic
+        if logic and hasattr(logic, 'record_statistic_event'):
+            logic.record_statistic_event(stat_name, amount)
 
     def reset_statistics(self):
         """Reset all statistics to zero"""

--- a/src/brain_statistics_tab.py
+++ b/src/brain_statistics_tab.py
@@ -244,6 +244,7 @@ class StatisticsTab(BrainBaseTab):
                 squid_stats = getattr(self.tamagotchi_logic.squid, 'statistics', None)
                 if squid_stats:
                     squid_stats.reset()
+                    self.tamagotchi_logic._observe_current_neuron_count()
                     self._sync_from_squid_statistics()
                     self.update_display()
 

--- a/src/brain_tool.py
+++ b/src/brain_tool.py
@@ -204,7 +204,7 @@ class SquidBrainWindow(QtWidgets.QMainWindow):
         ]:
             if hasattr(self, tab_attr):
                 tab = getattr(self, tab_attr)
-                if hasattr(tab, 'set_tamagotchi_logic') and self.tamagotchi_logic:
+                if hasattr(tab, 'set_tamagotchi_logic'):
                     tab.set_tamagotchi_logic(tamagotchi_logic)
 
     def _check_bridge_import(self):

--- a/src/brain_tool.py
+++ b/src/brain_tool.py
@@ -193,7 +193,15 @@ class SquidBrainWindow(QtWidgets.QMainWindow):
                 print(f"  ✓ Loaded {len(self.brain_widget.output_bindings)} output bindings into Monitor")
         
         # Update all tabs
-        for tab_attr in ['memory_tab', 'network_tab', 'learning_tab', 'decisions_tab', 'about_tab']:
+        for tab_attr in [
+            'memory_tab',
+            'network_tab',
+            'nn_viz_tab',
+            'decisions_tab',
+            'personality_tab',
+            'statistics_tab',
+            'about_tab',
+        ]:
             if hasattr(self, tab_attr):
                 tab = getattr(self, tab_attr)
                 if hasattr(tab, 'set_tamagotchi_logic') and self.tamagotchi_logic:

--- a/src/brain_widget.py
+++ b/src/brain_widget.py
@@ -1173,10 +1173,7 @@ class BrainWidget(QtWidgets.QWidget):
             
             if neuron_name:
                 print(f"✨ Main thread: Created neuron {neuron_name}")
-                
-                # Emit signal to notify listeners (e.g., NetworkTab) of new neuron
-                self.neuronCreated.emit(neuron_name)
-                
+
                 # Handle pruning if needed
                 if self.pruning_enabled:
                     current_count = len(self.neuron_positions) - len(self.excluded_neurons)
@@ -1830,9 +1827,9 @@ class BrainWidget(QtWidgets.QWidget):
         else:
             # Fallback: synchronous check
             try:
-                result = self.check_neurogenesis_triggers(state_with_context)
-                if result:
-                    self._on_neurogenesis_complete({'should_create': True, **result})
+                # This path creates the neuron itself. The neurogenesis engine
+                # emits the same completed-birth event as the threaded path.
+                self.check_neurogenesis_triggers(state_with_context)
             except Exception as e:
                 print(f"⚠️ Error in neurogenesis check: {e}")
                 import traceback

--- a/src/interactions.py
+++ b/src/interactions.py
@@ -269,11 +269,7 @@ class RockInteractionManager:
             "is_positive": True
         }
 
-        # Update rocks thrown counter
-        if hasattr(self.squid, 'statistics'):
-            self.squid.statistics.total_rocks_thrown += 1
-
-        # Update statistics tab and achievements plugin
+        # Deliver the completed throw once to the canonical statistics model.
         if hasattr(self.logic, 'track_rock_thrown'):
             self.logic.track_rock_thrown()
         

--- a/src/interactions2.py
+++ b/src/interactions2.py
@@ -234,9 +234,9 @@ class PoopInteractionManager:
             "is_positive": False
         }
 
-        # Update poops thrown counter
-        if hasattr(self.squid, 'statistics'):
-            self.squid.statistics.total_poops_thrown += 1
+        # Deliver the completed throw once to the canonical statistics model.
+        if hasattr(self.logic, 'track_poop_thrown'):
+            self.logic.track_poop_thrown()
         
         # Add with moderate importance
         self.squid.memory_manager.add_short_term_memory(

--- a/src/neurogenesis.py
+++ b/src/neurogenesis.py
@@ -546,7 +546,14 @@ class EnhancedNeurogenesis:
         self.brain_widget.neurogenesis_highlight = {'neuron': neuron_name, 'start_time': time.time(), 'duration': 8.0 if trigger_type == 'connector' else 4.0, 'pulse_phase': 0}
         self._log_neuron_creation(neuron_name, trigger_type, spec, trigger_value_for_log)
         self._record_neurogenesis_memory(neuron_name)
+        self._notify_neuron_created(neuron_name)
         return neuron_name
+
+    def _notify_neuron_created(self, neuron_name: str):
+        """Emit one completed-birth event from the creation source."""
+        signal = getattr(self.brain_widget, 'neuronCreated', None)
+        if signal is not None:
+            signal.emit(neuron_name)
 
     def _record_neurogenesis_memory(self, neuron_name: str):
         """Permanently records a new neuron growth event in long-term memory."""
@@ -664,6 +671,7 @@ class EnhancedNeurogenesis:
         self.brain_widget.neurogenesis_highlight = {'neuron': neuron_name, 'start_time': time.time(), 'duration': 8.0, 'pulse_phase': 0}
         self.brain_widget.log_neurogenesis_event(neuron_name, "created", details={'trigger_type': 'connector', 'trigger_value': 1.0, 'specialization': 'orphan_rescue', 'display_name': func_neuron.display_name})
         self._record_neurogenesis_memory(neuron_name)
+        self._notify_neuron_created(neuron_name)
         print(f"🔗 Connector neuron {neuron_name} created to rescue {orphan_name} (connected to closest: {targets[0] if targets else 'None'})")
     
     def _set_neuron_appearance(self, name: str, func_neuron: FunctionalNeuron):

--- a/src/squid.py
+++ b/src/squid.py
@@ -1208,9 +1208,6 @@ class Squid:
                     'anxiety_reduction': True
                 })
 
-        if hasattr(self.tamagotchi_logic, 'brain_window') and hasattr(self.tamagotchi_logic.brain_window, 'statistics_tab'):
-            self.tamagotchi_logic.brain_window.statistics_tab.increment_stat('plants_interacted')
-
         # --- Reward for RL ---
         if hasattr(self.tamagotchi_logic, 'recent_positive_outcome'):
             self.tamagotchi_logic.recent_positive_outcome = True
@@ -1531,8 +1528,8 @@ class Squid:
 
         # Track distance - 80 pixels per movement
         if self.squid_x != prev_x or self.squid_y != prev_y:
-            if hasattr(self.tamagotchi_logic, 'brain_window') and hasattr(self.tamagotchi_logic.brain_window, 'statistics_tab'):
-                self.tamagotchi_logic.brain_window.statistics_tab.track_distance(80)
+            if hasattr(self.tamagotchi_logic, 'track_distance'):
+                self.tamagotchi_logic.track_distance(80)
 
         # Update animation frame and image
         if self.squid_direction in ["left", "right", "up", "down"]:
@@ -2383,5 +2380,4 @@ class Squid:
             self.update_squid_image()  # Changed to use method instead of direct pixmap set
         
         return distance
-
 

--- a/src/squid.py
+++ b/src/squid.py
@@ -1640,8 +1640,20 @@ class Squid:
 
         # Neurogenesis tracking
         if hasattr(self.tamagotchi_logic, 'neurogenesis_triggers'):
-            current = self.tamagotchi_logic.neurogenesis_triggers['positive_outcomes']
-            self.tamagotchi_logic.neurogenesis_triggers['positive_outcomes'] = min(current + reward_points, 5)
+            triggers = self.tamagotchi_logic.neurogenesis_triggers
+            current = triggers['positive_outcomes']
+            triggers['positive_outcomes'] = min(current + reward_points, 5)
+
+            # Food writes this trigger outside track_neurogenesis_triggers().
+            # Preserve its live maximum before the same simulation tick can
+            # decay the value.
+            statistics = getattr(self, 'statistics', None)
+            if statistics:
+                statistics.observe_neurogenesis_peaks(
+                    statistics.peak_novelty,
+                    statistics.peak_stress,
+                    triggers['positive_outcomes'],
+                )
 
         # Visual/behavioral effects
         self.tamagotchi_logic.remove_food(food_item)

--- a/src/squid.py
+++ b/src/squid.py
@@ -784,6 +784,9 @@ class Squid:
 
         # Wake up the squid
         self.is_sleeping = False
+        if hasattr(self.tamagotchi_logic, 'track_startle'):
+            self.tamagotchi_logic.track_startle()
+
         # self.sleepiness = 0  # Waking up this way doesn't remove all tiredness
         self.happiness = max(0, self.happiness - 25)  # Increased happiness decrease
         self.anxiety = min(100, self.anxiety + 60)    # Increased anxiety spike
@@ -1457,9 +1460,11 @@ class Squid:
 
         if self.is_sleeping:
             #print("Squid is sleeping, limited movement")
+            previous_x, previous_y = self.squid_x, self.squid_y
             if self.squid_y < self.ui.window_height - 120 - self.squid_height:
                 self.squid_y += self.base_vertical_speed * self.animation_speed
                 self.squid_item.setPos(self.squid_x, self.squid_y)
+            self._track_position_delta(previous_x, previous_y)
             self.current_frame = (self.current_frame + 1) % 2
             self.update_squid_image()
             return
@@ -1526,10 +1531,7 @@ class Squid:
         self.squid_x = squid_x_new
         self.squid_y = squid_y_new
 
-        # Track distance - 80 pixels per movement
-        if self.squid_x != prev_x or self.squid_y != prev_y:
-            if hasattr(self.tamagotchi_logic, 'track_distance'):
-                self.tamagotchi_logic.track_distance(80)
+        self._track_position_delta(prev_x, prev_y)
 
         # Update animation frame and image
         if self.squid_direction in ["left", "right", "up", "down"]:
@@ -1555,6 +1557,21 @@ class Squid:
             self.squid_direction = "right" if dx > 0 else "left"
         else:
             self.squid_direction = "down" if dy > 0 else "up"
+
+    def _track_position_delta(self, previous_x, previous_y):
+        """Record the actual distance moved at a coordinate update boundary."""
+        distance = math.hypot(
+            self.squid_x - previous_x,
+            self.squid_y - previous_y,
+        )
+        track_distance = getattr(
+            getattr(self, 'tamagotchi_logic', None),
+            'track_distance',
+            None,
+        )
+        if distance > 0 and track_distance:
+            track_distance(distance)
+        return distance
 
     def move_towards_position(self, target_pos):
         dx = target_pos.x() - (self.squid_x + self.squid_width // 2)
@@ -1862,10 +1879,14 @@ class Squid:
         self.poop_timer.start(poop_delay)
 
     def create_poop(self):
-        self.tamagotchi_logic.spawn_poop(self.squid_x + self.squid_width // 2, self.squid_y + self.squid_height)
+        created = self.tamagotchi_logic.spawn_poop(
+            self.squid_x + self.squid_width // 2,
+            self.squid_y + self.squid_height,
+        )
         # Add tracking
-        if hasattr(self.tamagotchi_logic, 'track_poop_created'):
+        if created and hasattr(self.tamagotchi_logic, 'track_poop_created'):
             self.tamagotchi_logic.track_poop_created()
+        return created
 
     def show_eating_effect(self):
         if not self.is_debug_mode():
@@ -2355,6 +2376,8 @@ class Squid:
         distance = math.hypot(dx, dy)  # More efficient than math.sqrt
         
         if distance > 5:  # Small threshold to prevent micro-movements
+            previous_x, previous_y = self.squid_x, self.squid_y
+
             # Normalize and scale by speed (removed temporary 1.5x boost)
             norm = max(distance, 0.1)  # Avoid division by zero
             move_x = (dx/norm) * self.base_squid_speed * self.animation_speed
@@ -2376,6 +2399,7 @@ class Squid:
             
             # Update graphics
             self.squid_item.setPos(self.squid_x, self.squid_y)
+            self._track_position_delta(previous_x, previous_y)
             self.current_frame = (self.current_frame + 1) % 2
             self.update_squid_image()  # Changed to use method instead of direct pixmap set
         

--- a/src/squid_statistics.py
+++ b/src/squid_statistics.py
@@ -163,9 +163,13 @@ class SquidStatistics:
     
     def load_statistics(self, data):
         """Load canonical statistics from a desktop ``statistics.json`` dict."""
+        # Loading replaces the current model. Without this reset, fields absent
+        # from an older or partial save leak in from the live session and create
+        # a hybrid of two different states.
+        self.__init__(self.squid)
+
         if data:
             self.total_age_seconds = data.get('total_age_seconds', 0)
-            self.start_time = time.time()
 
             for persisted_key, attribute_name in self._PERSISTENCE_KEYS.items():
                 if persisted_key in data:

--- a/src/squid_statistics.py
+++ b/src/squid_statistics.py
@@ -267,8 +267,16 @@ class SquidStatistics:
         )
 
     def reset(self):
-        """Reset the canonical statistics model."""
+        """Reset counters without discarding live or lifetime neuron state."""
+        current_neurons = self.current_neurons
+        max_neurons_reached = self.max_neurons_reached
         self.__init__(self.squid)
+        self.current_neurons = current_neurons
+        self.max_neurons_reached = max(
+            self.max_neurons_reached,
+            max_neurons_reached,
+            current_neurons,
+        )
 
     def update(self, elapsed_seconds):
         """Advance continuous statistics by an explicit elapsed duration."""

--- a/src/squid_statistics.py
+++ b/src/squid_statistics.py
@@ -4,9 +4,64 @@ import math
 # Distance tracking constants
 DISTANCE_ROLLOVER_LIMIT = 999_999_999  # ~1 billion pixels before rollover
 
-class SquidStatistics:
-    def __init__(self, squid):
 
+class SquidStatistics:
+    """Canonical lifetime statistics for a squid.
+
+    Simulation code records elapsed time and discrete domain events here. UI
+    components may mirror these values, but they must not derive or persist
+    their own competing counters.
+    """
+
+    _PERSISTENCE_KEYS = {
+        'distance_swam': 'distance_swam',
+        'distance_swam_multiplier': 'distance_swam_multiplier',
+        'sushi_eaten': 'sushi_consumed',
+        'cheese_eaten': 'cheese_consumed',
+        'total_memories_formed': 'total_memories_formed',
+        'highest_anxiety': 'highest_anxiety',
+        'lowest_happiness': 'lowest_happiness',
+        'highest_satisfaction': 'highest_satisfaction',
+        'other_squids_encountered': 'other_squids_encountered',
+        'rocks_thrown': 'total_rocks_thrown',
+        'poops_thrown': 'total_poops_thrown',
+        'total_env_interactions': 'total_env_interactions',
+        'ink_clouds_created': 'ink_clouds_created',
+        'plants_interacted': 'plants_interacted',
+        'total_sleep_time': 'time_spent_asleep',
+        'peak_novelty': 'peak_novelty',
+        'peak_stress': 'peak_stress',
+        'peak_reward': 'peak_reward',
+        'novelty_neurons_created': 'novelty_neurons_created',
+        'stress_neurons_created': 'stress_neurons_created',
+        'reward_neurons_created': 'reward_neurons_created',
+        'poops_created': 'poops_created',
+        'max_poops_cleaned': 'max_poops_cleaned',
+        'startles_experienced': 'startles_experienced',
+        'times_colour_changed': 'times_colour_changed',
+        'sickness_episodes': 'sickness_episodes',
+    }
+
+    _EVENT_KEYS = {
+        'cheese_eaten': 'cheese_consumed',
+        'sushi_eaten': 'sushi_consumed',
+        'poops_created': 'poops_created',
+        'poops_thrown': 'total_poops_thrown',
+        'max_poops_cleaned': 'max_poops_cleaned',
+        'startles_experienced': 'startles_experienced',
+        'ink_clouds_created': 'ink_clouds_created',
+        'times_colour_changed': 'times_colour_changed',
+        'rocks_thrown': 'total_rocks_thrown',
+        'plants_interacted': 'plants_interacted',
+    }
+
+    _NEURON_BIRTH_KEYS = {
+        'novelty': 'novelty_neurons_created',
+        'stress': 'stress_neurons_created',
+        'reward': 'reward_neurons_created',
+    }
+
+    def __init__(self, squid):
         self.squid = squid
         self.start_time = time.time()
         self.total_age_seconds = 0
@@ -38,6 +93,7 @@ class SquidStatistics:
         self.sickness_episodes = 0
         self.max_neurons_reached = 7
         self.current_neurons = 7
+        self._last_sickness_state = bool(getattr(squid, 'is_sick', False))
 
     def get_total_age_seconds(self):
         """Calculates the total persistent age in seconds."""
@@ -59,6 +115,19 @@ class SquidStatistics:
                 self.squid.tamagotchi_logic.show_message(
                     f"🌊 Distance counter rolled over! Now at {self.distance_swam_multiplier}x"
                 )
+
+    def add_distance(self, distance):
+        """Track an already calculated distance without making a view own it."""
+        distance = float(distance)
+        if distance < 0 or not math.isfinite(distance):
+            raise ValueError("distance must be a finite non-negative number")
+
+        self.distance_swam += distance
+        if self.distance_swam >= DISTANCE_ROLLOVER_LIMIT:
+            rollovers, self.distance_swam = divmod(
+                self.distance_swam, DISTANCE_ROLLOVER_LIMIT
+            )
+            self.distance_swam_multiplier += int(rollovers)
     
     def get_distance_display(self):
         '''Get formatted distance string with multiplier if needed'''
@@ -89,49 +158,93 @@ class SquidStatistics:
         return f"{hours_str} hr" + ("s" if whole_hours + half_hour != 1 else "")
     
     def load_statistics(self, data):
-        """Load statistics from saved data dictionary"""
-        if not data:
-            return
-            
-        # Core stats
-        self.total_age_seconds = data.get('total_age_seconds', 0)
-        self.distance_swam = data.get('distance_swam', 0)
-        self.distance_swam_multiplier = data.get('distance_swam_multiplier', 1)
-        
-        # Food consumption
-        self.sushi_consumed = data.get('sushi_eaten', 0)
-        self.cheese_consumed = data.get('cheese_eaten', 0)
-        
-        # Mental states
-        self.highest_anxiety = data.get('highest_anxiety', 0)
-        self.lowest_happiness = data.get('lowest_happiness', 100)
-        
-        # Object interactions
-        self.total_rocks_thrown = data.get('rocks_thrown', 0)
-        self.total_poops_thrown = data.get('poops_thrown', 0)
-        self.ink_clouds_created = data.get('ink_clouds_created', 0)
-        self.plants_interacted = data.get('plants_interacted', 0)
-        
-        # Other tracked stats
-        self.times_colour_changed = data.get('times_colour_changed', 0)
-        self.poops_created = data.get('poops_created', 0)
-        self.max_poops_cleaned = data.get('max_poops_cleaned', 0)
-        self.startles_experienced = data.get('startles_experienced', 0)
-        
-        # Time and health
-        self.time_spent_asleep = data.get('total_sleep_time', 0)
-        self.sickness_episodes = data.get('sickness_episodes', 0)
-        
-        # Neurogenesis
-        self.novelty_neurons_created = data.get('novelty_neurons_created', 0)
-        self.stress_neurons_created = data.get('stress_neurons_created', 0)
-        self.reward_neurons_created = data.get('reward_neurons_created', 0)
-        
-        # --- FIX: Ensure these are loaded correctly, defaulting to 7 ---
-        self.max_neurons_reached = data.get('max_neurons_reached', 7)
-        self.current_neurons = data.get('current_neurons', 7)
+        """Load canonical statistics from a desktop ``statistics.json`` dict."""
+        if data:
+            self.total_age_seconds = data.get('total_age_seconds', 0)
+            self.start_time = time.time()
 
-    def update(self):
+            for persisted_key, attribute_name in self._PERSISTENCE_KEYS.items():
+                if persisted_key in data:
+                    setattr(self, attribute_name, data[persisted_key])
+
+            current_neurons = max(
+                0, int(data.get('current_neurons', self.current_neurons))
+            )
+            saved_maximum = data.get('max_neurons_reached', current_neurons)
+            if saved_maximum is None:
+                saved_maximum = current_neurons
+
+            self.current_neurons = current_neurons
+            self.max_neurons_reached = max(
+                current_neurons, max(0, int(saved_maximum))
+            )
+
+        # Loading an already-sick squid resumes the same episode. It must not
+        # manufacture a fresh false -> true transition on the next tick.
+        self._last_sickness_state = bool(getattr(self.squid, 'is_sick', False))
+
+    def to_dict(self):
+        """Return the canonical desktop persistence representation."""
+        total_age_seconds = self.get_total_age_seconds()
+        data = {
+            persisted_key: getattr(self, attribute_name)
+            for persisted_key, attribute_name in self._PERSISTENCE_KEYS.items()
+        }
+        data.update({
+            'total_age_seconds': total_age_seconds,
+            'squid_age_minutes': int(total_age_seconds // 60),
+            'max_neurons_reached': self.max_neurons_reached,
+            'current_neurons': self.current_neurons,
+        })
+        return data
+
+    def increment(self, event_name, amount=1):
+        """Increment a legacy gameplay event on the canonical model."""
+        attribute_name = self._EVENT_KEYS.get(event_name)
+        if not attribute_name:
+            return False
+
+        setattr(self, attribute_name, getattr(self, attribute_name) + amount)
+        return True
+
+    def record_sickness_state(self, is_sick):
+        """Record one sickness episode for each false -> true transition."""
+        is_sick = bool(is_sick)
+        if is_sick and not self._last_sickness_state:
+            self.sickness_episodes += 1
+        self._last_sickness_state = is_sick
+
+    def record_neuron_birth(self, neuron_type, current_count=None):
+        """Record a completed neurogenesis event exactly once at its source."""
+        counter_name = self._NEURON_BIRTH_KEYS.get(neuron_type)
+        if counter_name:
+            setattr(self, counter_name, getattr(self, counter_name) + 1)
+
+        if current_count is None:
+            current_count = self.current_neurons + 1
+        self.observe_neuron_count(current_count)
+
+    def observe_neuron_count(self, current_count):
+        """Update the live count while preserving the lifetime maximum."""
+        current_count = int(current_count)
+        if current_count < 0:
+            raise ValueError("current neuron count cannot be negative")
+
+        self.current_neurons = current_count
+        self.max_neurons_reached = max(
+            self.max_neurons_reached, current_count
+        )
+
+    def reset(self):
+        """Reset the canonical statistics model."""
+        self.__init__(self.squid)
+
+    def update(self, elapsed_seconds=1.0):
+        """Advance continuous statistics by an explicit elapsed duration."""
+        elapsed_seconds = float(elapsed_seconds)
+        if elapsed_seconds < 0 or not math.isfinite(elapsed_seconds):
+            raise ValueError("elapsed_seconds must be a finite non-negative number")
+
         # Update peak mental states
         if self.squid.anxiety > self.highest_anxiety:
             self.highest_anxiety = self.squid.anxiety
@@ -139,34 +252,9 @@ class SquidStatistics:
             self.lowest_happiness = self.squid.happiness
         if self.squid.satisfaction > self.highest_satisfaction:
             self.highest_satisfaction = self.squid.satisfaction
-            
+
         if self.squid.is_sleeping:
-            self.time_spent_asleep += 1 # update is called every second
-
-        # --- Check and update peak neurogenesis values ---
-        if self.squid.tamagotchi_logic and self.squid.tamagotchi_logic.brain_window:
-            brain_widget = self.squid.tamagotchi_logic.brain_window.brain_widget
-            if brain_widget:
-                # 1. Update Neurogenesis Stats
-                if hasattr(brain_widget, 'neurogenesis_data'):
-                    neuro_data = brain_widget.neurogenesis_data
-                    current_novelty = neuro_data.get('novelty_counter', 0)
-                    current_stress = neuro_data.get('stress_counter', 0)
-                    current_reward = neuro_data.get('reward_counter', 0)
-
-                    if current_novelty > self.peak_novelty:
-                        self.peak_novelty = current_novelty
-                    if current_stress > self.peak_stress:
-                        self.peak_stress = current_stress
-                    if current_reward > self.peak_reward:
-                        self.peak_reward = current_reward
-                
-                # 2. Update Max Neurons Reached (FIX)
-                if hasattr(brain_widget, 'neuron_positions'):
-                    actual_count = len(brain_widget.neuron_positions)
-                    if actual_count > self.max_neurons_reached:
-                        self.max_neurons_reached = actual_count
-                    self.current_neurons = actual_count
+            self.time_spent_asleep += elapsed_seconds
 
     def get_sleep_time(self):
         hours = int(self.time_spent_asleep // 3600)

--- a/src/squid_statistics.py
+++ b/src/squid_statistics.py
@@ -20,6 +20,8 @@ class SquidStatistics:
         'sushi_eaten': 'sushi_consumed',
         'cheese_eaten': 'cheese_consumed',
         'total_memories_formed': 'total_memories_formed',
+        'max_short_term_memories': 'max_short_term_memories',
+        'max_long_term_memories': 'max_long_term_memories',
         'highest_anxiety': 'highest_anxiety',
         'lowest_happiness': 'lowest_happiness',
         'highest_satisfaction': 'highest_satisfaction',
@@ -68,6 +70,8 @@ class SquidStatistics:
         self.sushi_consumed = 0
         self.cheese_consumed = 0
         self.total_memories_formed = 0
+        self.max_short_term_memories = 0
+        self.max_long_term_memories = 0
         self.highest_anxiety = 0
         self.lowest_happiness = 100
         self.highest_satisfaction = 0
@@ -233,6 +237,33 @@ class SquidStatistics:
         self.current_neurons = current_count
         self.max_neurons_reached = max(
             self.max_neurons_reached, current_count
+        )
+
+    def observe_poop_count(self, current_count):
+        """Preserve the largest number of simultaneous poop items."""
+        current_count = int(current_count)
+        if current_count < 0:
+            raise ValueError("current poop count cannot be negative")
+
+        self.max_poops_cleaned = max(
+            self.max_poops_cleaned,
+            current_count,
+        )
+
+    def observe_memory_counts(self, short_term_count, long_term_count):
+        """Preserve lifetime maxima for both memory stores."""
+        short_term_count = int(short_term_count)
+        long_term_count = int(long_term_count)
+        if short_term_count < 0 or long_term_count < 0:
+            raise ValueError("memory counts cannot be negative")
+
+        self.max_short_term_memories = max(
+            self.max_short_term_memories,
+            short_term_count,
+        )
+        self.max_long_term_memories = max(
+            self.max_long_term_memories,
+            long_term_count,
         )
 
     def reset(self):

--- a/src/squid_statistics.py
+++ b/src/squid_statistics.py
@@ -1,5 +1,8 @@
-import time
+import logging
 import math
+import time
+
+logger = logging.getLogger(__name__)
 
 # Distance tracking constants
 DISTANCE_ROLLOVER_LIMIT = 999_999_999  # ~1 billion pixels before rollover
@@ -107,18 +110,18 @@ class SquidStatistics:
     def update_distance(self, dx, dy):
         '''Track distance traveled by squid with rollover protection'''
         distance = math.sqrt(dx*dx + dy*dy)
-        self.distance_swam += distance
-        
-        # Check for rollover and reset with multiplier
-        if self.distance_swam >= DISTANCE_ROLLOVER_LIMIT:
-            self.distance_swam = self.distance_swam - DISTANCE_ROLLOVER_LIMIT
-            self.distance_swam_multiplier += 1
-            
+        previous_multiplier = self.distance_swam_multiplier
+        self.add_distance(distance)
+
+        if (
+            self.distance_swam_multiplier != previous_multiplier
+            and hasattr(self.squid, 'tamagotchi_logic')
+        ):
             # Log the rollover event
-            if hasattr(self.squid, 'tamagotchi_logic'):
-                self.squid.tamagotchi_logic.show_message(
-                    f"🌊 Distance counter rolled over! Now at {self.distance_swam_multiplier}x"
-                )
+            self.squid.tamagotchi_logic.show_message(
+                "🌊 Distance counter rolled over! Now at "
+                f"{self.distance_swam_multiplier}x"
+            )
 
     def add_distance(self, distance):
         """Track an already calculated distance without making a view own it."""
@@ -255,6 +258,7 @@ class SquidStatistics:
         """Increment a legacy gameplay event on the canonical model."""
         attribute_name = self._EVENT_KEYS.get(event_name)
         if not attribute_name:
+            logger.debug("Unknown statistic event: %s", event_name)
             return False
 
         setattr(self, attribute_name, getattr(self, attribute_name) + amount)

--- a/src/squid_statistics.py
+++ b/src/squid_statistics.py
@@ -160,7 +160,35 @@ class SquidStatistics:
 
         hours_str = f"{whole_hours}" if half_hour == 0 else f"{whole_hours}.5"
         return f"{hours_str} hr" + ("s" if whole_hours + half_hour != 1 else "")
-    
+
+    @staticmethod
+    def _coerce_non_negative_number(value, default):
+        """Return a finite non-negative number or the field's default."""
+        if value is None or isinstance(value, bool):
+            return default
+
+        try:
+            number = float(value)
+        except (TypeError, ValueError, OverflowError):
+            return default
+
+        if number < 0 or not math.isfinite(number):
+            return default
+
+        if isinstance(value, (int, float)):
+            return value
+        if isinstance(default, int) and number.is_integer():
+            return int(number)
+        return number
+
+    @classmethod
+    def _coerce_loaded_count(cls, value, default):
+        """Return a non-negative integer count or the field's default."""
+        number = cls._coerce_non_negative_number(value, default)
+        if isinstance(number, bool) or not float(number).is_integer():
+            return default
+        return int(number)
+
     def load_statistics(self, data):
         """Load canonical statistics from a desktop ``statistics.json`` dict."""
         # Loading replaces the current model. Without this reset, fields absent
@@ -169,22 +197,39 @@ class SquidStatistics:
         self.__init__(self.squid)
 
         if data:
-            self.total_age_seconds = data.get('total_age_seconds', 0)
+            self.total_age_seconds = self._coerce_non_negative_number(
+                data.get('total_age_seconds', self.total_age_seconds),
+                self.total_age_seconds,
+            )
 
             for persisted_key, attribute_name in self._PERSISTENCE_KEYS.items():
                 if persisted_key in data:
-                    setattr(self, attribute_name, data[persisted_key])
+                    default = getattr(self, attribute_name)
+                    setattr(
+                        self,
+                        attribute_name,
+                        self._coerce_non_negative_number(
+                            data[persisted_key],
+                            default,
+                        ),
+                    )
 
             current_neurons = max(
-                0, int(data.get('current_neurons', self.current_neurons))
+                0,
+                self._coerce_loaded_count(
+                    data.get('current_neurons', self.current_neurons),
+                    self.current_neurons,
+                ),
             )
-            saved_maximum = data.get('max_neurons_reached', current_neurons)
-            if saved_maximum is None:
-                saved_maximum = current_neurons
+            saved_maximum = self._coerce_loaded_count(
+                data.get('max_neurons_reached', current_neurons),
+                current_neurons,
+            )
 
             self.current_neurons = current_neurons
             self.max_neurons_reached = max(
-                current_neurons, max(0, int(saved_maximum))
+                current_neurons,
+                saved_maximum,
             )
 
         # Loading an already-sick squid resumes the same episode. It must not
@@ -270,6 +315,24 @@ class SquidStatistics:
             long_term_count,
         )
 
+    def observe_neurogenesis_peaks(self, novelty, stress, reward):
+        """Preserve lifetime maxima for the three live trigger values."""
+        for attribute_name, value in (
+            ('peak_novelty', novelty),
+            ('peak_stress', stress),
+            ('peak_reward', reward),
+        ):
+            current_peak = getattr(self, attribute_name)
+            observed_value = self._coerce_non_negative_number(
+                value,
+                current_peak,
+            )
+            setattr(
+                self,
+                attribute_name,
+                max(current_peak, observed_value),
+            )
+
     def reset(self):
         """Reset counters without discarding live or lifetime neuron state."""
         current_neurons = self.current_neurons
@@ -282,8 +345,8 @@ class SquidStatistics:
             current_neurons,
         )
 
-    def update(self, elapsed_seconds):
-        """Advance continuous statistics by an explicit elapsed duration."""
+    def update(self, elapsed_seconds=1.0):
+        """Advance continuous statistics, defaulting to the legacy one-second tick."""
         elapsed_seconds = float(elapsed_seconds)
         if elapsed_seconds < 0 or not math.isfinite(elapsed_seconds):
             raise ValueError("elapsed_seconds must be a finite non-negative number")

--- a/src/squid_statistics.py
+++ b/src/squid_statistics.py
@@ -3,6 +3,7 @@ import math
 
 # Distance tracking constants
 DISTANCE_ROLLOVER_LIMIT = 999_999_999  # ~1 billion pixels before rollover
+DEFAULT_NEURON_COUNT = 8
 
 
 class SquidStatistics:
@@ -90,8 +91,8 @@ class SquidStatistics:
         self.startles_experienced = 0
         self.times_colour_changed = 0
         self.sickness_episodes = 0
-        self.max_neurons_reached = 7
-        self.current_neurons = 7
+        self.max_neurons_reached = DEFAULT_NEURON_COUNT
+        self.current_neurons = DEFAULT_NEURON_COUNT
         self._last_sickness_state = bool(getattr(squid, 'is_sick', False))
 
     def get_total_age_seconds(self):

--- a/src/squid_statistics.py
+++ b/src/squid_statistics.py
@@ -47,7 +47,6 @@ class SquidStatistics:
         'sushi_eaten': 'sushi_consumed',
         'poops_created': 'poops_created',
         'poops_thrown': 'total_poops_thrown',
-        'max_poops_cleaned': 'max_poops_cleaned',
         'startles_experienced': 'startles_experienced',
         'ink_clouds_created': 'ink_clouds_created',
         'times_colour_changed': 'times_colour_changed',
@@ -239,7 +238,7 @@ class SquidStatistics:
         """Reset the canonical statistics model."""
         self.__init__(self.squid)
 
-    def update(self, elapsed_seconds=1.0):
+    def update(self, elapsed_seconds):
         """Advance continuous statistics by an explicit elapsed duration."""
         elapsed_seconds = float(elapsed_seconds)
         if elapsed_seconds < 0 or not math.isfinite(elapsed_seconds):

--- a/src/tamagotchi_logic.py
+++ b/src/tamagotchi_logic.py
@@ -3351,7 +3351,7 @@ class TamagotchiLogic:
         if not hasattr(self, 'poop_interaction'):
             self.setup_poop_interaction()
         
-        if not hasattr(self.squid, 'current_poop_target'):
+        if not getattr(self.squid, 'current_poop_target', None):
             return
         
         poop = self.squid.current_poop_target

--- a/src/tamagotchi_logic.py
+++ b/src/tamagotchi_logic.py
@@ -266,6 +266,30 @@ class TamagotchiLogic:
         Shows images/ng.png above the squid's head for 4 seconds
         and records a long-term memory of the event.
         """
+        brain_widget = getattr(self.brain_window, 'brain_widget', None)
+        neuron_type = None
+        current_count = None
+
+        if brain_widget:
+            current_count = len(getattr(brain_widget, 'neuron_positions', {}))
+            neurogenesis = getattr(brain_widget, 'enhanced_neurogenesis', None)
+            functional_neurons = getattr(neurogenesis, 'functional_neurons', {})
+            functional_neuron = functional_neurons.get(neuron_name)
+            neuron_type = getattr(functional_neuron, 'neuron_type', None)
+
+            if neuron_type is None:
+                details = getattr(brain_widget, 'neurogenesis_data', {}).get(
+                    'new_neurons_details', {}
+                ).get(neuron_name, {})
+                neuron_type = details.get('trigger_type')
+
+        self.track_neuron_creation(neuron_type, current_count)
+
+        # The creation signal is emitted before optional pruning. Re-observe
+        # the settled live count on the next event-loop turn without reducing
+        # the lifetime maximum recorded at birth.
+        QtCore.QTimer.singleShot(0, self._observe_current_neuron_count)
+
         # Show the ng icon above the squid's head for 4 seconds
         if hasattr(self.squid, 'show_neurogenesis_icon'):
             self.squid.show_neurogenesis_icon()
@@ -1138,9 +1162,6 @@ class TamagotchiLogic:
                 )
                 QtCore.QTimer.singleShot(5000, self.squid.end_ink_flee)
 
-            if hasattr(self.brain_window, 'statistics_tab'):
-                self.brain_window.statistics_tab.increment_stat('startles_experienced')
-
             # --- resilience / anxiety / ink logic --------------------------
             stress_neuron_count = 0
             if self.brain_window and hasattr(self.brain_window, 'brain_widget'):
@@ -1272,15 +1293,13 @@ class TamagotchiLogic:
         fade_out_animation.start()
         self.statistics_window.award(-250)
 
-        # Update ink clouds counter in squid.statistics (for save/load persistence)
+        # Record the event once on the canonical model.
         if hasattr(self, 'squid') and hasattr(self.squid, 'statistics'):
-            self.squid.statistics.ink_clouds_created = getattr(
-                self.squid.statistics, 'ink_clouds_created', 0
-            ) + 1
+            self.squid.statistics.increment('ink_clouds_created')
         
-        # Update ink clouds in brain statistics tab (for UI display)
+        # Refresh the read-only statistics projection.
         if hasattr(self.brain_window, 'statistics_tab'):
-            self.brain_window.statistics_tab.increment_stat('ink_clouds_created')
+            self.brain_window.statistics_tab.update_statistics()
         
         
         # Backup timer to force remove after 10 seconds in case animation fails
@@ -1329,9 +1348,13 @@ class TamagotchiLogic:
             self.brain_window.statistics_tab.increment_stat('poops_created')
             # Update max poops if needed
             current_poops = len(self.poop_items)
-            if current_poops > self.brain_window.statistics_tab.statistics['max_poops_cleaned']:
-                self.brain_window.statistics_tab.statistics['max_poops_cleaned'] = current_poops
-                self.brain_window.statistics_tab.update_display()
+            squid_statistics = getattr(self.squid, 'statistics', None)
+            if squid_statistics:
+                squid_statistics.max_poops_cleaned = max(
+                    squid_statistics.max_poops_cleaned,
+                    current_poops,
+                )
+                self.brain_window.statistics_tab.update_statistics()
 
     def track_rock_thrown(self):
         """Track when rock is thrown"""
@@ -1366,6 +1389,14 @@ class TamagotchiLogic:
         # 2. Paused?
         if self.simulation_speed == 0:
             return
+
+        # Record continuous model statistics once per simulation callback.
+        # The timer interval is explicit so accelerated timers and pauses do
+        # not turn a UI refresh cadence into the source of sleep duration.
+        squid_statistics = getattr(self.squid, 'statistics', None)
+        if squid_statistics:
+            elapsed_seconds = self.simulation_timer.interval() / 1000.0
+            squid_statistics.update(elapsed_seconds=elapsed_seconds)
         
         # Check for decorations message
         self._check_decorations_message()
@@ -1762,25 +1793,33 @@ class TamagotchiLogic:
         if random.random() < curious_chance:
             self.make_squid_curious()
 
-    def track_neuron_creation(self, neuron_type):
-        if hasattr(self.brain_window, 'statistics_tab'):
-            if neuron_type == 'novelty':
-                self.brain_window.statistics_tab.increment_stat('novelty_neurons_created')
-            elif neuron_type == 'stress':
-                self.brain_window.statistics_tab.increment_stat('stress_neurons_created')
-            elif neuron_type == 'reward':
-                self.brain_window.statistics_tab.increment_stat('reward_neurons_created')
+    def track_neuron_creation(self, neuron_type, current_count=None):
+        """Record one completed neurogenesis event on the canonical model."""
+        statistics = getattr(self.squid, 'statistics', None)
+        if not statistics:
+            return
 
-            current = self.brain_window.statistics_tab.statistics['current_neurons']
-            self.brain_window.statistics_tab.statistics['current_neurons'] = current + 1
-            self.brain_window.statistics_tab.update_display()
-            self.statistics_window.award(500)
+        statistics.record_neuron_birth(
+            neuron_type,
+            current_count=current_count,
+        )
+        statistics_tab = getattr(self.brain_window, 'statistics_tab', None)
+        if statistics_tab:
+            statistics_tab.update_statistics()
 
-    def track_neuron_counts(self, current_count, max_count):
-        """Track current and maximum neuron counts"""
-        if hasattr(self.brain_window, 'statistics_tab'):
-            self.brain_window.statistics_tab.update_current_neurons(current_count)
-            self.brain_window.statistics_tab.track_max_neurons(max_count)
+    def _observe_current_neuron_count(self):
+        """Record the live count after any post-birth pruning has settled."""
+        brain_widget = getattr(self.brain_window, 'brain_widget', None)
+        statistics = getattr(self.squid, 'statistics', None)
+        if not brain_widget or not statistics:
+            return
+
+        statistics.observe_neuron_count(
+            len(getattr(brain_widget, 'neuron_positions', {}))
+        )
+        statistics_tab = getattr(self.brain_window, 'statistics_tab', None)
+        if statistics_tab:
+            statistics_tab.update_statistics()
 
     def track_neurogenesis_triggers(self):
         """Update counters for neurogenesis triggers"""
@@ -2015,6 +2054,22 @@ class TamagotchiLogic:
         self.rps_game = RPSGame(self)
         self.rps_game.start_game()
 
+    def _set_sickness_state(self, is_sick):
+        """Keep squid state, mental-state visuals, and transition stats aligned."""
+        if self.squid is None:
+            return
+
+        is_sick = bool(is_sick)
+        self.squid.is_sick = is_sick
+
+        mental_state_manager = getattr(self.squid, 'mental_state_manager', None)
+        if mental_state_manager:
+            mental_state_manager.set_state("sick", is_sick)
+
+        statistics = getattr(self.squid, 'statistics', None)
+        if statistics:
+            statistics.record_sickness_state(is_sick)
+
     def give_medicine(self):
         
         # Get plugin results
@@ -2031,8 +2086,7 @@ class TamagotchiLogic:
             self.squid.mental_state_manager.is_state_active('sick'))):
             
             print("Debug: Applying medicine effects")
-            self.squid.is_sick = False
-            self.squid.mental_state_manager.set_state("sick", False)
+            self._set_sickness_state(False)
             
             self.squid.happiness = max(0, self.squid.happiness - 30)
             self.squid.sleepiness = min(100, self.squid.sleepiness + 50)
@@ -2221,9 +2275,9 @@ class TamagotchiLogic:
                     (self.hunger_threshold_time >= 10 * self.simulation_speed and
                     self.hunger_threshold_time <= 50 * self.simulation_speed)):
                     if random.random() < 0.8:
-                        self.squid.mental_state_manager.set_state("sick", True)
+                        self._set_sickness_state(True)
                 else:
-                    self.squid.mental_state_manager.set_state("sick", False)
+                    self._set_sickness_state(False)
 
                 # New logic for health decrease based on happiness and cleanliness
                 if self.squid.happiness < 20 and self.squid.cleanliness < 20:
@@ -2644,7 +2698,7 @@ class TamagotchiLogic:
         self.squid.cleanliness = 100
         self.squid.is_sleeping = False
         self.squid.health = 100
-        self.squid.is_sick = False
+        self._set_sickness_state(False)
 
         # Reset new neurons
         self.squid.satisfaction = 50
@@ -2745,6 +2799,11 @@ class TamagotchiLogic:
                 except ValueError:
                     pass
 
+            # Restore the canonical statistics model after squid state so an
+            # already-active sickness episode is resumed rather than recounted.
+            self.squid.statistics.load_statistics(data.get('statistics', {}))
+            self._set_sickness_state(getattr(self.squid, 'is_sick', False))
+
             # Load custom brain (Logic patched to load output bindings)
             custom_brain_data = data.get('custom_brain', {})
             custom_brain_loaded = False
@@ -2836,50 +2895,8 @@ class TamagotchiLogic:
             'name': getattr(self.squid, 'name', 'Squid'),  # Save squid name if it exists
         }
 
-        # Collect statistics as separate file
-        # Primary source: brain_window.statistics_tab (where gameplay updates go)
-        # Fallback: squid.statistics (legacy)
-        tab_stats = {}
-        if hasattr(self, 'brain_window') and hasattr(self.brain_window, 'statistics_tab'):
-            tab_stats = getattr(self.brain_window.statistics_tab, 'statistics', {})
-
-        squid_stats = self.squid.statistics
-
-        # Save using exact keys from StatisticsTab
-        statistics_data = {
-            # Age tracking
-            'total_age_seconds': squid_stats.get_total_age_seconds(),
-            'squid_age_minutes': tab_stats.get('squid_age_minutes', 0),
-
-            # Movement
-            'distance_swam': tab_stats.get('distance_swam', 0),
-
-            # Food consumption
-            'cheese_eaten': tab_stats.get('cheese_eaten', 0),
-            'sushi_eaten': tab_stats.get('sushi_eaten', 0),
-
-            # Poop tracking
-            'poops_created': tab_stats.get('poops_created', 0),
-            'max_poops_cleaned': tab_stats.get('max_poops_cleaned', 0),
-
-            # Interactions
-            'startles_experienced': tab_stats.get('startles_experienced', 0),
-            'ink_clouds_created': tab_stats.get('ink_clouds_created', 0),
-            'times_colour_changed': tab_stats.get('times_colour_changed', 0),
-            'rocks_thrown': tab_stats.get('rocks_thrown', 0),
-            'plants_interacted': tab_stats.get('plants_interacted', 0),
-
-            # Health/Sleep
-            'total_sleep_time': tab_stats.get('total_sleep_time', 0),
-            'sickness_episodes': tab_stats.get('sickness_episodes', 0),
-
-            # Neurogenesis
-            'novelty_neurons_created': tab_stats.get('novelty_neurons_created', 0),
-            'stress_neurons_created': tab_stats.get('stress_neurons_created', 0),
-            'reward_neurons_created': tab_stats.get('reward_neurons_created', 0),
-            'max_neurons_reached': tab_stats.get('max_neurons_reached', 0),
-            'current_neurons': tab_stats.get('current_neurons', 7),
-        }
+        # Statistics are owned by the model. The tab is a read-only projection.
+        statistics_data = self.squid.statistics.to_dict()
 
         # Collect tamagotchi logic state
         tamagotchi_logic_data = {
@@ -3019,6 +3036,8 @@ class TamagotchiLogic:
             squid_data = game_state['squid']
             
             self.squid.load_state(squid_data)
+            self.squid.statistics.load_statistics(save_data.get('statistics', {}))
+            self._set_sickness_state(getattr(self.squid, 'is_sick', False))
             
             # Load custom brain
             custom_brain_data = save_data.get('custom_brain')
@@ -3034,38 +3053,6 @@ class TamagotchiLogic:
             self.squid.memory_manager.short_term_memory = save_data.get('ShortTerm', [])
             self.squid.memory_manager.long_term_memory = save_data.get('LongTerm', [])
 
-            # Sync neurogenesis neuron counts with actual brain state
-            if hasattr(self.brain_window, 'brain_widget') and hasattr(self.brain_window.brain_widget, 'enhanced_neurogenesis'):
-                eng = self.brain_window.brain_widget.enhanced_neurogenesis
-                if hasattr(eng, 'functional_neurons'):
-                    # Count neurons by specialization type
-                    novelty_count = 0
-                    stress_count = 0
-                    reward_count = 0
-                    
-                    for neuron in eng.functional_neurons.values():
-                        if hasattr(neuron, 'specialization'):
-                            if neuron.specialization == 'novelty':
-                                novelty_count += 1
-                            elif neuron.specialization == 'stress':
-                                stress_count += 1
-                            elif neuron.specialization == 'reward':
-                                reward_count += 1
-                    
-                    # Update statistics tab with ground truth values
-                    if hasattr(self.brain_window, 'statistics_tab') and hasattr(self.brain_window.statistics_tab, 'statistics'):
-                        self.brain_window.statistics_tab.statistics['novelty_neurons_created'] = novelty_count
-                        self.brain_window.statistics_tab.statistics['stress_neurons_created'] = stress_count
-                        self.brain_window.statistics_tab.statistics['reward_neurons_created'] = reward_count
-                        self.brain_window.statistics_tab.update_display()
-                        print(f"✓ Synced neuron counts: {novelty_count} novelty, {stress_count} stress, {reward_count} reward")
-                    
-                    # Also sync with squid's internal statistics for consistency
-                    if hasattr(self, 'squid') and hasattr(self.squid, 'statistics'):
-                        self.squid.statistics.novelty_neurons_created = novelty_count
-                        self.squid.statistics.stress_neurons_created = stress_count
-                        self.squid.statistics.reward_neurons_created = reward_count
-            
             # Load decorations
             decorations_data = game_state.get('decorations', [])
             self.user_interface.load_decorations_data(decorations_data)

--- a/src/tamagotchi_logic.py
+++ b/src/tamagotchi_logic.py
@@ -1147,8 +1147,7 @@ class TamagotchiLogic:
             self.squid.current_speed = 180
             self.squid.direction = random.choice(['up', 'down', 'left', 'right'])
 
-            # A startle is one event whether or not it produces an ink cloud.
-            self._maybe_create_startle_ink_cloud(source)
+            # Record the accepted startle once on the model.
             self.track_startle()
 
             # --- resilience / anxiety / ink logic --------------------------
@@ -1293,19 +1292,6 @@ class TamagotchiLogic:
         
         # Backup timer to force remove after 10 seconds in case animation fails
         QtCore.QTimer.singleShot(10000, lambda: self.force_remove_ink_cloud(ink_cloud_item))
-
-    def _maybe_create_startle_ink_cloud(self, source):
-        """Create and finish one startle ink response when its roll succeeds."""
-        if source == "startled_awake" or random.random() >= 0.25:
-            return False
-
-        self.create_ink_cloud()
-        self.squid.status = "fleeing!"
-        self.squid.memory_manager.add_short_term_memory(
-            'behaviour', 'ink_cloud', 'Startled! Created an ink cloud'
-        )
-        QtCore.QTimer.singleShot(5000, self.squid.end_ink_flee)
-        return True
 
     def force_remove_ink_cloud(self, ink_cloud_item):
         """Force remove the ink cloud if it still exists after timeout"""

--- a/src/tamagotchi_logic.py
+++ b/src/tamagotchi_logic.py
@@ -352,38 +352,65 @@ class TamagotchiLogic:
         
 
     def update_squid_age(self):
-        if hasattr(self.brain_window, 'statistics_tab'):
-            age_min = int((time.time() - self.squid_birth_time) / 60)
-            self.brain_window.statistics_tab.statistics['squid_age_minutes'] = age_min
-            self.brain_window.statistics_tab.update_display()
+        """Refresh the age projection from the persistent model clock."""
+        self._refresh_statistics_tab()
+
+    def _refresh_statistics_tab(self):
+        """Refresh the optional statistics projection without owning data."""
+        brain_window = getattr(self, 'brain_window', None)
+        statistics_tab = getattr(brain_window, 'statistics_tab', None)
+        if statistics_tab:
+            statistics_tab.update_statistics()
+
+    def record_statistic_event(self, event_name, amount=1):
+        """Record one discrete event on the model, then refresh the view."""
+        statistics = getattr(getattr(self, 'squid', None), 'statistics', None)
+        if not statistics or not statistics.increment(event_name, amount):
+            return False
+
+        self._refresh_statistics_tab()
+        return True
+
+    def track_distance(self, distance):
+        """Record movement on the model, then refresh the optional view."""
+        statistics = getattr(getattr(self, 'squid', None), 'statistics', None)
+        if not statistics:
+            return
+
+        statistics.add_distance(distance)
+        self._refresh_statistics_tab()
 
 
     def track_poop_thrown(self):
-        if hasattr(self.brain_window, 'statistics_tab'):
-            self.brain_window.statistics_tab.increment_stat('poops_thrown')
+        self.record_statistic_event('poops_thrown')
 
     def update_highest_anxiety(self, value):
-        if hasattr(self.brain_window, 'statistics_tab'):
-            tab = self.brain_window.statistics_tab
-            if value > tab.statistics['highest_anxiety']:
-                tab.statistics['highest_anxiety'] = value
-                tab.update_display()
+        statistics = getattr(getattr(self, 'squid', None), 'statistics', None)
+        if statistics:
+            statistics.highest_anxiety = max(
+                statistics.highest_anxiety,
+                value,
+            )
+            self._refresh_statistics_tab()
 
     def update_lowest_happiness(self, value):
-        if hasattr(self.brain_window, 'statistics_tab'):
-            tab = self.brain_window.statistics_tab
-            if value < tab.statistics['lowest_happiness']:
-                tab.statistics['lowest_happiness'] = value
-                tab.update_display()
+        statistics = getattr(getattr(self, 'squid', None), 'statistics', None)
+        if statistics:
+            statistics.lowest_happiness = min(
+                statistics.lowest_happiness,
+                value,
+            )
+            self._refresh_statistics_tab()
 
     def update_max_memories(self):
-        if hasattr(self.brain_window, 'statistics_tab') and hasattr(self.squid, 'memory_manager'):
-            tab = self.brain_window.statistics_tab
-            stm = len(self.squid.memory_manager.short_term_memory)
-            ltm = len(self.squid.memory_manager.long_term_memory)
-            tab.statistics['max_short_term_memories'] = max(tab.statistics['max_short_term_memories'], stm)
-            tab.statistics['max_long_term_memories'] = max(tab.statistics['max_long_term_memories'], ltm)
-            tab.update_display()
+        statistics = getattr(getattr(self, 'squid', None), 'statistics', None)
+        memory_manager = getattr(getattr(self, 'squid', None), 'memory_manager', None)
+        if statistics and memory_manager:
+            statistics.observe_memory_counts(
+                len(memory_manager.short_term_memory),
+                len(memory_manager.long_term_memory),
+            )
+            self._refresh_statistics_tab()
 
     
 
@@ -1281,13 +1308,7 @@ class TamagotchiLogic:
         fade_out_animation.start()
         self.statistics_window.award(-250)
 
-        # Record the event once on the canonical model.
-        if hasattr(self, 'squid') and hasattr(self.squid, 'statistics'):
-            self.squid.statistics.increment('ink_clouds_created')
-        
-        # Refresh the read-only statistics projection.
-        if hasattr(self.brain_window, 'statistics_tab'):
-            self.brain_window.statistics_tab.update_statistics()
+        self.record_statistic_event('ink_clouds_created')
         
         
         # Backup timer to force remove after 10 seconds in case animation fails
@@ -1324,45 +1345,38 @@ class TamagotchiLogic:
 
     def track_food_consumed(self, food_item):
         """Track when food is consumed"""
-        if hasattr(self.brain_window, 'statistics_tab'):
-            if getattr(food_item, 'is_sushi', False):
-                self.brain_window.statistics_tab.increment_stat('sushi_eaten')
-            else:
-                self.brain_window.statistics_tab.increment_stat('cheese_eaten')
+        event_name = (
+            'sushi_eaten'
+            if getattr(food_item, 'is_sushi', False)
+            else 'cheese_eaten'
+        )
+        self.record_statistic_event(event_name)
 
     def track_poop_created(self):
         """Track when poop is created"""
-        if hasattr(self.brain_window, 'statistics_tab'):
-            self.brain_window.statistics_tab.increment_stat('poops_created')
-            # Update max poops if needed
-            current_poops = len(self.poop_items)
-            squid_statistics = getattr(self.squid, 'statistics', None)
-            if squid_statistics:
-                squid_statistics.max_poops_cleaned = max(
-                    squid_statistics.max_poops_cleaned,
-                    current_poops,
-                )
-                self.brain_window.statistics_tab.update_statistics()
+        statistics = getattr(getattr(self, 'squid', None), 'statistics', None)
+        if not statistics:
+            return
+
+        statistics.increment('poops_created')
+        statistics.observe_poop_count(len(self.poop_items))
+        self._refresh_statistics_tab()
 
     def track_rock_thrown(self):
         """Track when rock is thrown"""
-        if hasattr(self.brain_window, 'statistics_tab'):
-            self.brain_window.statistics_tab.increment_stat('rocks_thrown')
+        self.record_statistic_event('rocks_thrown')
 
     def track_plant_interaction(self):
         """Track when squid interacts with plants"""
-        if hasattr(self.brain_window, 'statistics_tab'):
-            self.brain_window.statistics_tab.increment_stat('plants_interacted')
+        self.record_statistic_event('plants_interacted')
+
+    def track_colour_changed(self):
+        """Track a completed squid colour change."""
+        self.record_statistic_event('times_colour_changed')
 
     def track_startle(self):
         """Track when squid is startled"""
-        statistics = getattr(self.squid, 'statistics', None)
-        if statistics:
-            statistics.increment('startles_experienced')
-
-        statistics_tab = getattr(self.brain_window, 'statistics_tab', None)
-        if statistics_tab:
-            statistics_tab.update_statistics()
+        self.record_statistic_event('startles_experienced')
 
 
             ######################################### UPDATE_SIMULATION METHOD BELOW

--- a/src/tamagotchi_logic.py
+++ b/src/tamagotchi_logic.py
@@ -254,7 +254,7 @@ class TamagotchiLogic:
         # Connect neurogenesis signal to show icon and store long-term memory
         if hasattr(self.brain_window, 'brain_widget'):
             self.brain_window.brain_widget.neuronCreated.connect(self._on_neurogenesis_icon_and_memory)
-            self._observe_current_neuron_count()
+            self.refresh_neuron_count()
 
     def handle_vision_update(self, result):
         """Cache the latest vision result and push to brain immediately."""
@@ -272,7 +272,7 @@ class TamagotchiLogic:
         current_count = None
 
         if brain_widget:
-            current_count = len(getattr(brain_widget, 'neuron_positions', {}))
+            current_count = self._live_neuron_count()
             neurogenesis = getattr(brain_widget, 'enhanced_neurogenesis', None)
             functional_neurons = getattr(neurogenesis, 'functional_neurons', {})
             functional_neuron = functional_neurons.get(neuron_name)
@@ -289,7 +289,7 @@ class TamagotchiLogic:
         # The creation signal is emitted before optional pruning. Re-observe
         # the settled live count on the next event-loop turn without reducing
         # the lifetime maximum recorded at birth.
-        QtCore.QTimer.singleShot(0, self._observe_current_neuron_count)
+        QtCore.QTimer.singleShot(0, self.refresh_neuron_count)
 
         # Show the ng icon above the squid's head for 4 seconds
         if hasattr(self.squid, 'show_neurogenesis_icon'):
@@ -1147,21 +1147,9 @@ class TamagotchiLogic:
             self.squid.current_speed = 180
             self.squid.direction = random.choice(['up', 'down', 'left', 'right'])
 
-            # ------------------------------------------------------------------
-            # NEW: 15 % ink-cloud trigger (skip if woken from sleep)
-            # ------------------------------------------------------------------
-            if source != "startled_awake" and random.random() < 0.25:
-                self.create_ink_cloud()
-            
-            # Track startle in statistics (was only in else block)
-            if hasattr(self.brain_window, 'statistics_tab'):
-                self.brain_window.statistics_tab.increment_stat('startles_experienced')
-                
-                self.squid.status = "fleeing!"
-                self.squid.memory_manager.add_short_term_memory(
-                    'behaviour', 'ink_cloud', 'Startled! Created an ink cloud'
-                )
-                QtCore.QTimer.singleShot(5000, self.squid.end_ink_flee)
+            # A startle is one event whether or not it produces an ink cloud.
+            self._maybe_create_startle_ink_cloud(source)
+            self.track_startle()
 
             # --- resilience / anxiety / ink logic --------------------------
             stress_neuron_count = 0
@@ -1306,6 +1294,19 @@ class TamagotchiLogic:
         # Backup timer to force remove after 10 seconds in case animation fails
         QtCore.QTimer.singleShot(10000, lambda: self.force_remove_ink_cloud(ink_cloud_item))
 
+    def _maybe_create_startle_ink_cloud(self, source):
+        """Create and finish one startle ink response when its roll succeeds."""
+        if source == "startled_awake" or random.random() >= 0.25:
+            return False
+
+        self.create_ink_cloud()
+        self.squid.status = "fleeing!"
+        self.squid.memory_manager.add_short_term_memory(
+            'behaviour', 'ink_cloud', 'Startled! Created an ink cloud'
+        )
+        QtCore.QTimer.singleShot(5000, self.squid.end_ink_flee)
+        return True
+
     def force_remove_ink_cloud(self, ink_cloud_item):
         """Force remove the ink cloud if it still exists after timeout"""
         if ink_cloud_item in self.squid.ui.scene.items():
@@ -1369,8 +1370,13 @@ class TamagotchiLogic:
 
     def track_startle(self):
         """Track when squid is startled"""
-        if hasattr(self.brain_window, 'statistics_tab'):
-            self.brain_window.statistics_tab.increment_stat('startles_experienced')
+        statistics = getattr(self.squid, 'statistics', None)
+        if statistics:
+            statistics.increment('startles_experienced')
+
+        statistics_tab = getattr(self.brain_window, 'statistics_tab', None)
+        if statistics_tab:
+            statistics_tab.update_statistics()
 
 
             ######################################### UPDATE_SIMULATION METHOD BELOW
@@ -1392,11 +1398,13 @@ class TamagotchiLogic:
             return
 
         # Record continuous model statistics once per simulation callback.
-        # The timer interval is explicit so accelerated timers and pauses do
-        # not turn a UI refresh cadence into the source of sleep duration.
+        # Sleep duration is elapsed wall-clock time, matching the former
+        # time.time()-based statistic. The timer already fires more often at
+        # higher simulation speeds, so multiplying by simulation_speed would
+        # overcount the time the squid was actually asleep.
         squid_statistics = getattr(self.squid, 'statistics', None)
         if squid_statistics:
-            elapsed_seconds = self.simulation_timer.interval() / 1000.0
+            elapsed_seconds = self._statistics_elapsed_seconds()
             squid_statistics.update(elapsed_seconds=elapsed_seconds)
         
         # Check for decorations message
@@ -1797,27 +1805,42 @@ class TamagotchiLogic:
     def track_neuron_creation(self, neuron_type, current_count):
         """Record one completed neurogenesis event on the canonical model."""
         statistics = getattr(self.squid, 'statistics', None)
-        if not statistics:
-            return
+        if statistics:
+            statistics.record_neuron_birth(
+                neuron_type,
+                current_count=current_count,
+            )
 
-        statistics.record_neuron_birth(
-            neuron_type,
-            current_count=current_count,
-        )
+        statistics_window = getattr(self, 'statistics_window', None)
+        if statistics_window:
+            statistics_window.add_score_for_neuron_creation()
+
         statistics_tab = getattr(self.brain_window, 'statistics_tab', None)
         if statistics_tab:
             statistics_tab.update_statistics()
 
-    def _observe_current_neuron_count(self):
+    def _statistics_elapsed_seconds(self):
+        """Return wall-clock seconds represented by one simulation callback."""
+        return self.simulation_timer.interval() / 1000.0
+
+    def _live_neuron_count(self):
+        """Count positioned network neurons, excluding only matching keys."""
+        brain_widget = getattr(self.brain_window, 'brain_widget', None)
+        if not brain_widget:
+            return 0
+
+        positions = getattr(brain_widget, 'neuron_positions', {})
+        excluded = set(getattr(brain_widget, 'excluded_neurons', ()) or ())
+        return sum(name not in excluded for name in positions)
+
+    def refresh_neuron_count(self):
         """Record the live count after any post-birth pruning has settled."""
         brain_widget = getattr(self.brain_window, 'brain_widget', None)
         statistics = getattr(self.squid, 'statistics', None)
         if not brain_widget or not statistics:
             return
 
-        statistics.observe_neuron_count(
-            len(getattr(brain_widget, 'neuron_positions', {}))
-        )
+        statistics.observe_neuron_count(self._live_neuron_count())
         statistics_tab = getattr(self.brain_window, 'statistics_tab', None)
         if statistics_tab:
             statistics_tab.update_statistics()
@@ -2824,7 +2847,7 @@ class TamagotchiLogic:
             brain_state = data.get('brain_state', {})
             if brain_state and hasattr(self, 'brain_window'):
                 self.brain_window.set_brain_state(brain_state)
-                self._observe_current_neuron_count()
+                self.refresh_neuron_count()
                 
                 # Manually load bindings if not using custom brain
                 # This handles standard saves where bindings are stored in 'brain_state'
@@ -3049,7 +3072,7 @@ class TamagotchiLogic:
             # Load brain state
             brain_state = save_data.get('brain_state', {})
             self.brain_window.set_brain_state(brain_state)
-            self._observe_current_neuron_count()
+            self.refresh_neuron_count()
             
             # Load memories
             self.squid.memory_manager.short_term_memory = save_data.get('ShortTerm', [])

--- a/src/tamagotchi_logic.py
+++ b/src/tamagotchi_logic.py
@@ -1816,7 +1816,7 @@ class TamagotchiLogic:
         if random.random() < curious_chance:
             self.make_squid_curious()
 
-    def track_neuron_creation(self, neuron_type, current_count):
+    def track_neuron_creation(self, neuron_type, current_count=None):
         """Record one completed neurogenesis event on the canonical model."""
         statistics = getattr(self.squid, 'statistics', None)
         if statistics:
@@ -1899,6 +1899,14 @@ class TamagotchiLogic:
             self.neurogenesis_triggers['positive_outcomes'] = max(
                 0,
                 self.neurogenesis_triggers['positive_outcomes'] - 0.2
+            )
+
+        statistics = getattr(self.squid, 'statistics', None)
+        if statistics:
+            statistics.observe_neurogenesis_peaks(
+                self.neurogenesis_triggers['novel_objects'],
+                self.neurogenesis_triggers['high_stress_cycles'] / 10.0,
+                self.neurogenesis_triggers['positive_outcomes'],
             )
         
         # Debug output if in debug mode

--- a/src/tamagotchi_logic.py
+++ b/src/tamagotchi_logic.py
@@ -2835,7 +2835,9 @@ class TamagotchiLogic:
             squid_data = game_state.get('squid', {})
             if squid_data:
                 for attr, value in squid_data.items():
-                    if hasattr(self.squid, attr):
+                    # Statistics are a canonical model, not replaceable squid
+                    # state. Older saves may nest their persisted values here.
+                    if attr != 'statistics' and hasattr(self.squid, attr):
                         setattr(self.squid, attr, value)
 
             # Restore personality
@@ -2848,7 +2850,11 @@ class TamagotchiLogic:
 
             # Restore the canonical statistics model after squid state so an
             # already-active sickness episode is resumed rather than recounted.
-            self.squid.statistics.load_statistics(data.get('statistics', {}))
+            statistics_data = data.get(
+                'statistics',
+                squid_data.get('statistics', {}),
+            )
+            self.squid.statistics.load_statistics(statistics_data)
             self._set_sickness_state(getattr(self.squid, 'is_sick', False))
 
             # Load custom brain (Logic patched to load output bindings)

--- a/src/tamagotchi_logic.py
+++ b/src/tamagotchi_logic.py
@@ -254,6 +254,7 @@ class TamagotchiLogic:
         # Connect neurogenesis signal to show icon and store long-term memory
         if hasattr(self.brain_window, 'brain_widget'):
             self.brain_window.brain_widget.neuronCreated.connect(self._on_neurogenesis_icon_and_memory)
+            self._observe_current_neuron_count()
 
     def handle_vision_update(self, result):
         """Cache the latest vision result and push to brain immediately."""
@@ -1793,7 +1794,7 @@ class TamagotchiLogic:
         if random.random() < curious_chance:
             self.make_squid_curious()
 
-    def track_neuron_creation(self, neuron_type, current_count=None):
+    def track_neuron_creation(self, neuron_type, current_count):
         """Record one completed neurogenesis event on the canonical model."""
         statistics = getattr(self.squid, 'statistics', None)
         if not statistics:
@@ -2276,8 +2277,7 @@ class TamagotchiLogic:
                     self.hunger_threshold_time <= 50 * self.simulation_speed)):
                     if random.random() < 0.8:
                         self._set_sickness_state(True)
-                else:
-                    self._set_sickness_state(False)
+                # Sickness persists until medicine or an explicit game reset.
 
                 # New logic for health decrease based on happiness and cleanliness
                 if self.squid.happiness < 20 and self.squid.cleanliness < 20:
@@ -2824,6 +2824,7 @@ class TamagotchiLogic:
             brain_state = data.get('brain_state', {})
             if brain_state and hasattr(self, 'brain_window'):
                 self.brain_window.set_brain_state(brain_state)
+                self._observe_current_neuron_count()
                 
                 # Manually load bindings if not using custom brain
                 # This handles standard saves where bindings are stored in 'brain_state'
@@ -3048,6 +3049,7 @@ class TamagotchiLogic:
             # Load brain state
             brain_state = save_data.get('brain_state', {})
             self.brain_window.set_brain_state(brain_state)
+            self._observe_current_neuron_count()
             
             # Load memories
             self.squid.memory_manager.short_term_memory = save_data.get('ShortTerm', [])

--- a/src/tamagotchi_logic.py
+++ b/src/tamagotchi_logic.py
@@ -1068,6 +1068,20 @@ class TamagotchiLogic:
 
     def stop(self):
         """Stop all timers and clean up resources"""
+        brain_widget = getattr(
+            getattr(self, 'brain_window', None),
+            'brain_widget',
+            None,
+        )
+        neuron_created = getattr(brain_widget, 'neuronCreated', None)
+        if neuron_created:
+            try:
+                neuron_created.disconnect(
+                    self._on_neurogenesis_icon_and_memory
+                )
+            except (TypeError, RuntimeError):
+                pass
+
         # Stop Vision Worker
         if hasattr(self, 'vision_worker') and self.vision_worker:
             self.vision_worker.stop()
@@ -2686,6 +2700,8 @@ class TamagotchiLogic:
             # Notify vision worker of scene change
             if hasattr(self.squid, 'mark_scene_objects_dirty'):
                 self.squid.mark_scene_objects_dirty()
+            return True
+        return False
 
     def animate_poops(self):
         if self.squid is not None:

--- a/tests/test_squid_statistics.py
+++ b/tests/test_squid_statistics.py
@@ -67,6 +67,16 @@ class SquidStatisticsTests(unittest.TestCase):
         self.assertEqual(self.statistics.max_neurons_reached, 12)
         self.assertEqual(self.statistics.reward_neurons_created, 1)
 
+    def test_other_lifetime_maxima_never_decrease(self):
+        self.statistics.observe_poop_count(5)
+        self.statistics.observe_poop_count(2)
+        self.statistics.observe_memory_counts(3, 7)
+        self.statistics.observe_memory_counts(1, 4)
+
+        self.assertEqual(self.statistics.max_poops_cleaned, 5)
+        self.assertEqual(self.statistics.max_short_term_memories, 3)
+        self.assertEqual(self.statistics.max_long_term_memories, 7)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_squid_statistics.py
+++ b/tests/test_squid_statistics.py
@@ -1,6 +1,12 @@
 import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock
 
-from src.squid_statistics import DEFAULT_NEURON_COUNT, SquidStatistics
+from src.squid_statistics import (
+    DEFAULT_NEURON_COUNT,
+    DISTANCE_ROLLOVER_LIMIT,
+    SquidStatistics,
+)
 
 
 class FakeSquid:
@@ -94,6 +100,32 @@ class SquidStatisticsTests(unittest.TestCase):
         self.assertEqual(self.statistics.max_poops_cleaned, 5)
         self.assertEqual(self.statistics.max_short_term_memories, 3)
         self.assertEqual(self.statistics.max_long_term_memories, 7)
+
+    def test_update_distance_handles_multiple_rollovers_in_one_step(self):
+        show_message = Mock()
+        self.squid.tamagotchi_logic = SimpleNamespace(
+            show_message=show_message,
+        )
+        self.statistics.distance_swam = DISTANCE_ROLLOVER_LIMIT - 10
+
+        self.statistics.update_distance(
+            DISTANCE_ROLLOVER_LIMIT * 2 + 10,
+            0,
+        )
+
+        self.assertEqual(self.statistics.distance_swam, 0)
+        self.assertEqual(self.statistics.distance_swam_multiplier, 4)
+        show_message.assert_called_once_with(
+            "🌊 Distance counter rolled over! Now at 4x"
+        )
+
+    def test_unknown_event_is_logged_without_mutating_counters(self):
+        with self.assertLogs("src.squid_statistics", level="DEBUG") as logs:
+            accepted = self.statistics.increment("misspelled_event")
+
+        self.assertFalse(accepted)
+        self.assertIn("misspelled_event", logs.output[0])
+        self.assertEqual(self.statistics.cheese_consumed, 0)
 
 
 if __name__ == "__main__":

--- a/tests/test_squid_statistics.py
+++ b/tests/test_squid_statistics.py
@@ -37,6 +37,13 @@ class SquidStatisticsTests(unittest.TestCase):
 
         self.assertEqual(self.statistics.time_spent_asleep, 2.75)
 
+    def test_zero_argument_update_preserves_one_second_compatibility(self):
+        self.squid.is_sleeping = True
+
+        self.statistics.update()
+
+        self.assertEqual(self.statistics.time_spent_asleep, 1)
+
     def test_sickness_counts_only_false_to_true_transitions(self):
         self.statistics.record_sickness_state(False)
         self.statistics.record_sickness_state(True)

--- a/tests/test_squid_statistics.py
+++ b/tests/test_squid_statistics.py
@@ -1,6 +1,6 @@
 import unittest
 
-from src.squid_statistics import SquidStatistics
+from src.squid_statistics import DEFAULT_NEURON_COUNT, SquidStatistics
 
 
 class FakeSquid:
@@ -16,6 +16,14 @@ class SquidStatisticsTests(unittest.TestCase):
     def setUp(self):
         self.squid = FakeSquid()
         self.statistics = SquidStatistics(self.squid)
+
+    def test_default_neuron_count_matches_the_standard_brain(self):
+        self.assertEqual(DEFAULT_NEURON_COUNT, 8)
+        self.assertEqual(self.statistics.current_neurons, DEFAULT_NEURON_COUNT)
+        self.assertEqual(
+            self.statistics.max_neurons_reached,
+            DEFAULT_NEURON_COUNT,
+        )
 
     def test_sleep_time_uses_explicit_elapsed_time(self):
         self.squid.is_sleeping = True

--- a/tests/test_squid_statistics.py
+++ b/tests/test_squid_statistics.py
@@ -67,6 +67,17 @@ class SquidStatisticsTests(unittest.TestCase):
         self.assertEqual(self.statistics.max_neurons_reached, 12)
         self.assertEqual(self.statistics.reward_neurons_created, 1)
 
+    def test_reset_preserves_current_and_lifetime_neuron_counts(self):
+        self.statistics.observe_neuron_count(12)
+        self.statistics.observe_neuron_count(9)
+        self.statistics.cheese_consumed = 3
+
+        self.statistics.reset()
+
+        self.assertEqual(self.statistics.current_neurons, 9)
+        self.assertEqual(self.statistics.max_neurons_reached, 12)
+        self.assertEqual(self.statistics.cheese_consumed, 0)
+
     def test_other_lifetime_maxima_never_decrease(self):
         self.statistics.observe_poop_count(5)
         self.statistics.observe_poop_count(2)

--- a/tests/test_squid_statistics.py
+++ b/tests/test_squid_statistics.py
@@ -1,0 +1,64 @@
+import unittest
+
+from src.squid_statistics import SquidStatistics
+
+
+class FakeSquid:
+    def __init__(self):
+        self.anxiety = 10
+        self.happiness = 90
+        self.satisfaction = 20
+        self.is_sleeping = False
+        self.is_sick = False
+
+
+class SquidStatisticsTests(unittest.TestCase):
+    def setUp(self):
+        self.squid = FakeSquid()
+        self.statistics = SquidStatistics(self.squid)
+
+    def test_sleep_time_uses_explicit_elapsed_time(self):
+        self.squid.is_sleeping = True
+        self.statistics.update(elapsed_seconds=2.5)
+
+        self.squid.is_sleeping = False
+        self.statistics.update(elapsed_seconds=10)
+
+        self.squid.is_sleeping = True
+        self.statistics.update(elapsed_seconds=0.25)
+
+        self.assertEqual(self.statistics.time_spent_asleep, 2.75)
+
+    def test_sickness_counts_only_false_to_true_transitions(self):
+        self.statistics.record_sickness_state(False)
+        self.statistics.record_sickness_state(True)
+        self.statistics.record_sickness_state(True)
+        self.statistics.record_sickness_state(False)
+        self.statistics.record_sickness_state(False)
+        self.statistics.record_sickness_state(True)
+
+        self.assertEqual(self.statistics.sickness_episodes, 2)
+
+    def test_neuron_birth_updates_type_and_lifetime_maximum_once(self):
+        self.statistics.record_neuron_birth("novelty", current_count=8)
+        self.statistics.record_neuron_birth("stress", current_count=9)
+        self.statistics.record_neuron_birth("connector", current_count=10)
+
+        self.assertEqual(self.statistics.novelty_neurons_created, 1)
+        self.assertEqual(self.statistics.stress_neurons_created, 1)
+        self.assertEqual(self.statistics.reward_neurons_created, 0)
+        self.assertEqual(self.statistics.current_neurons, 10)
+        self.assertEqual(self.statistics.max_neurons_reached, 10)
+
+    def test_lifetime_maximum_never_decreases_with_current_count(self):
+        self.statistics.observe_neuron_count(12)
+        self.statistics.observe_neuron_count(8)
+        self.statistics.record_neuron_birth("reward", current_count=9)
+
+        self.assertEqual(self.statistics.current_neurons, 9)
+        self.assertEqual(self.statistics.max_neurons_reached, 12)
+        self.assertEqual(self.statistics.reward_neurons_created, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_statistics_event_wiring.py
+++ b/tests/test_statistics_event_wiring.py
@@ -1,0 +1,192 @@
+import io
+import unittest
+from contextlib import redirect_stdout
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from src.brain_widget import BrainWidget
+from src.neurogenesis import EnhancedNeurogenesis
+from src.squid_statistics import SquidStatistics
+from src.tamagotchi_logic import TamagotchiLogic
+
+
+class RecordingSignal:
+    def __init__(self):
+        self.events = []
+
+    def emit(self, neuron_name):
+        self.events.append(neuron_name)
+
+
+class NotifyingNeurogenesis:
+    def __init__(self, brain_widget, neuron_name):
+        self.brain_widget = brain_widget
+        self.neuron_name = neuron_name
+
+    def capture_experience_context(self, **_kwargs):
+        return object()
+
+    def should_create_neuron(self, _context):
+        return True
+
+    def create_functional_neuron(self, _context, **_kwargs):
+        EnhancedNeurogenesis._notify_neuron_created(self, self.neuron_name)
+        return self.neuron_name
+
+
+class FakeSquid:
+    def __init__(self):
+        self.anxiety = 10
+        self.happiness = 90
+        self.satisfaction = 20
+        self.is_sleeping = False
+        self.is_sick = False
+        self.statistics = SquidStatistics(self)
+
+
+class RecordingMentalStateManager:
+    def __init__(self):
+        self.states = []
+
+    def set_state(self, state_name, is_active):
+        self.states.append((state_name, is_active))
+
+
+class StatisticsEventWiringTests(unittest.TestCase):
+    def test_threaded_completion_does_not_duplicate_engine_notification(self):
+        signal = RecordingSignal()
+        controller = SimpleNamespace(
+            _pending_neurogenesis_check=True,
+            neuronCreated=signal,
+            pruning_enabled=False,
+            update=lambda: None,
+        )
+        controller.enhanced_neurogenesis = NotifyingNeurogenesis(
+            controller,
+            "novelty_threaded",
+        )
+
+        with redirect_stdout(io.StringIO()):
+            BrainWidget._on_neurogenesis_complete(
+                controller,
+                {
+                    "should_create": True,
+                    "neuron_type": "novelty",
+                    "state_context": {},
+                },
+            )
+
+        self.assertEqual(signal.events, ["novelty_threaded"])
+
+    def test_synchronous_fallback_does_not_delegate_an_already_created_birth(self):
+        signal = RecordingSignal()
+        delegated_results = []
+
+        def create_synchronously(_state):
+            signal.emit("stress_synchronous")
+            return {"should_create": True}
+
+        controller = SimpleNamespace(
+            _pending_neurogenesis_check=False,
+            enhanced_neurogenesis=SimpleNamespace(),
+            state={},
+            _use_threaded_processing=False,
+            check_neurogenesis_triggers=create_synchronously,
+            _on_neurogenesis_complete=delegated_results.append,
+        )
+
+        BrainWidget._periodic_neurogenesis_check(controller)
+
+        self.assertEqual(signal.events, ["stress_synchronous"])
+        self.assertEqual(delegated_results, [])
+        self.assertFalse(controller._pending_neurogenesis_check)
+
+    def test_orphan_rescue_emits_one_completed_birth(self):
+        signal = RecordingSignal()
+        brain_widget = SimpleNamespace(
+            neuronCreated=signal,
+            neuron_positions={
+                "orphan": (100, 100),
+                "hunger": (300, 300),
+            },
+            state={
+                "orphan": 50.0,
+                "hunger": 50.0,
+            },
+            excluded_neurons=[],
+            weights={},
+            visible_neurons=set(),
+            neuron_shapes={},
+            state_colors={},
+            log_neurogenesis_event=lambda *_args, **_kwargs: None,
+        )
+        neurogenesis = object.__new__(EnhancedNeurogenesis)
+        neurogenesis.brain_widget = brain_widget
+        neurogenesis.functional_neurons = {}
+
+        with (
+            redirect_stdout(io.StringIO()),
+            patch("src.neurogenesis.random.randint", return_value=0),
+            patch("src.neurogenesis.random.uniform", return_value=0.5),
+            patch("src.neurogenesis.random.random", return_value=0.75),
+        ):
+            neurogenesis.rescue_orphan("orphan")
+
+        self.assertEqual(signal.events, ["connector_rescue"])
+
+    def test_one_birth_signal_updates_the_model_once_without_the_tab(self):
+        squid = FakeSquid()
+        neuron_name = "reward_test"
+        brain_widget = SimpleNamespace(
+            neuron_positions={f"neuron_{index}": (0, 0) for index in range(9)},
+            enhanced_neurogenesis=SimpleNamespace(
+                functional_neurons={
+                    neuron_name: SimpleNamespace(neuron_type="reward"),
+                }
+            ),
+            neurogenesis_data={},
+        )
+        logic = object.__new__(TamagotchiLogic)
+        logic.squid = squid
+        logic.brain_window = SimpleNamespace(
+            brain_widget=brain_widget,
+            statistics_tab=None,
+        )
+
+        with patch("src.tamagotchi_logic.QtCore.QTimer.singleShot") as single_shot:
+            logic._on_neurogenesis_icon_and_memory(neuron_name)
+
+        self.assertEqual(squid.statistics.reward_neurons_created, 1)
+        self.assertEqual(squid.statistics.current_neurons, 9)
+        self.assertEqual(squid.statistics.max_neurons_reached, 9)
+        single_shot.assert_called_once_with(
+            0,
+            logic._observe_current_neuron_count,
+        )
+
+    def test_sickness_funnel_keeps_state_and_transition_count_aligned(self):
+        squid = FakeSquid()
+        squid.mental_state_manager = RecordingMentalStateManager()
+        logic = object.__new__(TamagotchiLogic)
+        logic.squid = squid
+
+        logic._set_sickness_state(True)
+        logic._set_sickness_state(True)
+        logic._set_sickness_state(False)
+        logic._set_sickness_state(True)
+
+        self.assertTrue(squid.is_sick)
+        self.assertEqual(squid.statistics.sickness_episodes, 2)
+        self.assertEqual(
+            squid.mental_state_manager.states,
+            [
+                ("sick", True),
+                ("sick", True),
+                ("sick", False),
+                ("sick", True),
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_statistics_event_wiring.py
+++ b/tests/test_statistics_event_wiring.py
@@ -75,6 +75,37 @@ class RecordingMentalStateManager:
 
 
 class StatisticsEventWiringTests(unittest.TestCase):
+    def test_live_neurogenesis_triggers_update_lifetime_peaks(self):
+        squid = FakeSquid()
+        squid.anxiety = 80
+        logic = object.__new__(TamagotchiLogic)
+        logic.squid = squid
+        logic.neurogenesis_triggers = {
+            "novel_objects": 1.5,
+            "high_stress_cycles": 20,
+            "positive_outcomes": 3,
+        }
+        logic.new_object_encountered = True
+        logic.recent_positive_outcome = True
+        logic.add_thought = Mock()
+        logic.debug_mode = False
+
+        with patch("src.tamagotchi_logic.random.random", return_value=1):
+            logic.track_neurogenesis_triggers()
+
+        self.assertEqual(squid.statistics.peak_novelty, 2.5)
+        self.assertEqual(squid.statistics.peak_stress, 2.1)
+        self.assertEqual(squid.statistics.peak_reward, 4)
+
+        squid.anxiety = 10
+        logic.new_object_encountered = False
+        logic.recent_positive_outcome = False
+        logic.track_neurogenesis_triggers()
+
+        self.assertEqual(squid.statistics.peak_novelty, 2.5)
+        self.assertEqual(squid.statistics.peak_stress, 2.1)
+        self.assertEqual(squid.statistics.peak_reward, 4)
+
     def test_stop_disconnects_the_old_neurogenesis_listener(self):
         signal = ConnectableSignal()
         old_logic = object.__new__(TamagotchiLogic)
@@ -121,28 +152,51 @@ class StatisticsEventWiringTests(unittest.TestCase):
 
         self.assertEqual(signal.events, ["novelty_threaded"])
 
-    def test_synchronous_fallback_does_not_delegate_an_already_created_birth(self):
+    def test_synchronous_fallback_real_check_creates_one_birth_without_delegating(
+        self,
+    ):
         signal = RecordingSignal()
         delegated_results = []
 
-        def create_synchronously(_state):
-            signal.emit("stress_synchronous")
-            return {"should_create": True}
-
         controller = SimpleNamespace(
             _pending_neurogenesis_check=False,
-            enhanced_neurogenesis=SimpleNamespace(),
-            state={},
+            neuronCreated=signal,
+            state={
+                "neurogenesis_active": True,
+                "anxiety": 95,
+                "recent_actions": [],
+            },
             _use_threaded_processing=False,
-            check_neurogenesis_triggers=create_synchronously,
             _on_neurogenesis_complete=delegated_results.append,
+            experience_buffer=SimpleNamespace(add_experience=Mock()),
+            pruning_enabled=False,
+        )
+        controller.enhanced_neurogenesis = NotifyingNeurogenesis(
+            controller,
+            "stress_synchronous",
+        )
+        controller.check_neurogenesis_triggers = lambda state: (
+            BrainWidget.check_neurogenesis_triggers(controller, state)
         )
 
-        BrainWidget._periodic_neurogenesis_check(controller)
+        with redirect_stdout(io.StringIO()):
+            BrainWidget._periodic_neurogenesis_check(controller)
 
         self.assertEqual(signal.events, ["stress_synchronous"])
         self.assertEqual(delegated_results, [])
         self.assertFalse(controller._pending_neurogenesis_check)
+
+    def test_one_argument_neuron_creation_preserves_compatibility(self):
+        squid = FakeSquid()
+        logic = object.__new__(TamagotchiLogic)
+        logic.squid = squid
+        logic.statistics_window = None
+        logic.brain_window = SimpleNamespace(statistics_tab=None)
+
+        logic.track_neuron_creation("novelty")
+
+        self.assertEqual(squid.statistics.novelty_neurons_created, 1)
+        self.assertEqual(squid.statistics.current_neurons, 9)
 
     def test_orphan_rescue_emits_one_completed_birth(self):
         signal = RecordingSignal()

--- a/tests/test_statistics_event_wiring.py
+++ b/tests/test_statistics_event_wiring.py
@@ -106,6 +106,51 @@ class StatisticsEventWiringTests(unittest.TestCase):
         self.assertEqual(squid.statistics.peak_stress, 2.1)
         self.assertEqual(squid.statistics.peak_reward, 4)
 
+    def test_food_reward_peak_is_recorded_before_same_tick_decay(self):
+        logic = object.__new__(TamagotchiLogic)
+        logic.neurogenesis_triggers = {
+            "novel_objects": 0,
+            "high_stress_cycles": 0,
+            "positive_outcomes": 4,
+        }
+        logic.new_object_encountered = False
+        logic.recent_positive_outcome = False
+        logic.debug_mode = False
+        logic.add_thought = Mock()
+        logic.remove_food = Mock()
+        logic.track_food_consumed = Mock()
+
+        squid = object.__new__(Squid)
+        squid.hunger = 50
+        squid.happiness = 50
+        squid.satisfaction = 50
+        squid.anxiety = 10
+        squid.personality = None
+        squid.tamagotchi_logic = logic
+        squid.statistics_window = SimpleNamespace(award=Mock())
+        squid.memory_manager = SimpleNamespace(
+            add_short_term_memory=Mock(),
+        )
+        squid.statistics = SquidStatistics(squid)
+        squid.finish_eating = Mock()
+        squid.show_eating_effect = Mock()
+        squid.start_poop_timer = Mock()
+        logic.squid = squid
+
+        with patch("src.squid.QTimer.singleShot"):
+            squid.eat(SimpleNamespace(is_sushi=False))
+
+        self.assertEqual(logic.neurogenesis_triggers["positive_outcomes"], 5)
+        self.assertEqual(squid.statistics.peak_reward, 5)
+
+        logic.track_neurogenesis_triggers()
+
+        self.assertEqual(
+            logic.neurogenesis_triggers["positive_outcomes"],
+            4.8,
+        )
+        self.assertEqual(squid.statistics.peak_reward, 5)
+
     def test_stop_disconnects_the_old_neurogenesis_listener(self):
         signal = ConnectableSignal()
         old_logic = object.__new__(TamagotchiLogic)

--- a/tests/test_statistics_event_wiring.py
+++ b/tests/test_statistics_event_wiring.py
@@ -635,6 +635,24 @@ class StatisticsEventWiringTests(unittest.TestCase):
         self.assertEqual(squid.statistics.total_poops_thrown, 1)
         statistics_tab.update_statistics.assert_called_once_with()
 
+    def test_poop_interaction_ignores_missing_or_cleared_legacy_target(self):
+        squids = (
+            SimpleNamespace(),
+            SimpleNamespace(current_poop_target=None),
+        )
+
+        for squid in squids:
+            with self.subTest(has_target=hasattr(squid, "current_poop_target")):
+                logic = object.__new__(TamagotchiLogic)
+                logic.poop_interaction = object()
+                logic.squid = squid
+
+                logic.check_poop_interaction()
+
+                self.assertIsNone(
+                    getattr(squid, "current_poop_target", None),
+                )
+
     def test_plant_completion_delivers_one_model_event(self):
         squid = FakeSquid()
         squid.curiosity = 10

--- a/tests/test_statistics_event_wiring.py
+++ b/tests/test_statistics_event_wiring.py
@@ -213,44 +213,65 @@ class StatisticsEventWiringTests(unittest.TestCase):
                 )
                 self.assertAlmostEqual(elapsed, 1.0, places=2)
 
-    def test_startle_ink_followup_runs_only_when_cloud_is_created(self):
-        memory_manager = SimpleNamespace(
-            add_short_term_memory=Mock(),
+    def test_one_startle_creates_at_most_one_ink_cloud(self):
+        cases = (
+            ("first startle", "environment", False, 0.0, 1),
+            ("later successful roll", "environment", True, 0.0, 1),
+            ("later failed roll", "environment", True, 0.99, 0),
+            ("awakened later successful roll", "startled_awake", True, 0.0, 1),
         )
-        squid = SimpleNamespace(
-            status="startled",
-            memory_manager=memory_manager,
-            end_ink_flee=Mock(),
-        )
-        logic = object.__new__(TamagotchiLogic)
-        logic.squid = squid
-        logic.create_ink_cloud = Mock()
 
-        with (
-            patch("src.tamagotchi_logic.random.random", return_value=0.5),
-            patch("src.tamagotchi_logic.QtCore.QTimer.singleShot") as single_shot,
-        ):
-            self.assertFalse(logic._maybe_create_startle_ink_cloud("environment"))
+        for name, source, already_startled, ink_roll, expected_clouds in cases:
+            with self.subTest(name=name):
+                squid = FakeSquid()
+                squid.status = "roaming"
+                squid.is_fleeing = False
+                squid.personality = None
+                squid.mental_state_manager = RecordingMentalStateManager()
+                squid.memory_manager = SimpleNamespace(
+                    add_short_term_memory=Mock(),
+                )
 
-        logic.create_ink_cloud.assert_not_called()
-        memory_manager.add_short_term_memory.assert_not_called()
-        single_shot.assert_not_called()
-        self.assertEqual(squid.status, "startled")
+                logic = object.__new__(TamagotchiLogic)
+                logic.mental_states_enabled = True
+                logic.initial_startle_allowed = True
+                logic.startle_cooldown_max = 10
+                logic.squid = squid
+                logic.statistics_window = SimpleNamespace(award=Mock())
+                logic.brain_window = SimpleNamespace(
+                    brain_widget=SimpleNamespace(
+                        get_stress_neuron_count=lambda: 0,
+                    ),
+                    statistics_tab=None,
+                )
+                logic.create_ink_cloud = Mock()
+                logic.show_message = Mock()
 
-        with (
-            patch("src.tamagotchi_logic.random.random", return_value=0.1),
-            patch("src.tamagotchi_logic.QtCore.QTimer.singleShot") as single_shot,
-        ):
-            self.assertTrue(logic._maybe_create_startle_ink_cloud("environment"))
+                if already_startled:
+                    logic._has_startled_before = True
 
-        logic.create_ink_cloud.assert_called_once_with()
-        memory_manager.add_short_term_memory.assert_called_once_with(
-            'behaviour',
-            'ink_cloud',
-            'Startled! Created an ink cloud',
-        )
-        single_shot.assert_called_once_with(5000, squid.end_ink_flee)
-        self.assertEqual(squid.status, "fleeing!")
+                with (
+                    patch(
+                        "src.tamagotchi_logic.random.random",
+                        return_value=ink_roll,
+                    ),
+                    patch(
+                        "src.tamagotchi_logic.random.choice",
+                        return_value="right",
+                    ),
+                    patch(
+                        "src.tamagotchi_logic.QtCore.QTimer.singleShot"
+                    ) as single_shot,
+                ):
+                    logic.startle_squid(source)
+
+                self.assertEqual(
+                    logic.create_ink_cloud.call_count,
+                    expected_clouds,
+                )
+                self.assertEqual(squid.statistics.startles_experienced, 1)
+                squid.memory_manager.add_short_term_memory.assert_called_once()
+                self.assertEqual(single_shot.call_count, 1)
 
     def test_startle_count_does_not_depend_on_statistics_tab(self):
         squid = FakeSquid()

--- a/tests/test_statistics_event_wiring.py
+++ b/tests/test_statistics_event_wiring.py
@@ -22,6 +22,24 @@ class RecordingSignal:
         self.events.append(neuron_name)
 
 
+class ConnectableSignal:
+    def __init__(self):
+        self.slots = []
+
+    def connect(self, slot):
+        self.slots.append(slot)
+
+    def disconnect(self, slot):
+        try:
+            self.slots.remove(slot)
+        except ValueError as error:
+            raise TypeError("slot is not connected") from error
+
+    def emit(self, *args):
+        for slot in list(self.slots):
+            slot(*args)
+
+
 class NotifyingNeurogenesis:
     def __init__(self, brain_widget, neuron_name):
         self.brain_widget = brain_widget
@@ -57,6 +75,27 @@ class RecordingMentalStateManager:
 
 
 class StatisticsEventWiringTests(unittest.TestCase):
+    def test_stop_disconnects_the_old_neurogenesis_listener(self):
+        signal = ConnectableSignal()
+        old_logic = object.__new__(TamagotchiLogic)
+        new_logic = object.__new__(TamagotchiLogic)
+        old_handler = Mock()
+        new_handler = Mock()
+        old_logic._on_neurogenesis_icon_and_memory = old_handler
+        new_logic._on_neurogenesis_icon_and_memory = new_handler
+        old_logic.brain_window = SimpleNamespace(
+            brain_widget=SimpleNamespace(neuronCreated=signal),
+        )
+        signal.connect(old_handler)
+        signal.connect(new_handler)
+
+        old_logic.stop()
+        old_logic.stop()
+        signal.emit("novelty_after_restart")
+
+        old_handler.assert_not_called()
+        new_handler.assert_called_once_with("novelty_after_restart")
+
     def test_threaded_completion_does_not_duplicate_engine_notification(self):
         signal = RecordingSignal()
         controller = SimpleNamespace(
@@ -571,6 +610,217 @@ class StatisticsEventWiringTests(unittest.TestCase):
                 ("sick", True),
             ],
         )
+
+    def test_click_wake_records_one_accepted_startle(self):
+        squid = object.__new__(Squid)
+        squid.is_sleeping = True
+        squid.happiness = 90
+        squid.anxiety = 10
+        squid.status = "sleeping"
+        squid.statistics_window = SimpleNamespace(award=Mock())
+        squid.tamagotchi_logic = SimpleNamespace(
+            track_startle=Mock(),
+            show_message=Mock(),
+            create_ink_cloud=Mock(),
+        )
+        squid.show_startled_icon = Mock()
+
+        with (
+            patch("src.squid.random.random", return_value=1.0),
+            patch("src.squid.QtCore.QTimer"),
+        ):
+            squid.startle_awake()
+            squid.startle_awake()
+
+        self.assertFalse(squid.is_sleeping)
+        squid.tamagotchi_logic.track_startle.assert_called_once_with()
+
+    def test_poop_is_counted_only_after_a_successful_spawn(self):
+        for created in (False, True):
+            with self.subTest(created=created):
+                squid = object.__new__(Squid)
+                squid.squid_x = 100
+                squid.squid_y = 200
+                squid.squid_width = 20
+                squid.squid_height = 30
+                squid.tamagotchi_logic = SimpleNamespace(
+                    spawn_poop=Mock(return_value=created),
+                    track_poop_created=Mock(),
+                )
+
+                result = squid.create_poop()
+
+                self.assertIs(result, created)
+                if created:
+                    squid.tamagotchi_logic.track_poop_created.assert_called_once_with()
+                else:
+                    squid.tamagotchi_logic.track_poop_created.assert_not_called()
+
+    def test_spawn_poop_reports_capacity_rejection(self):
+        logic = object.__new__(TamagotchiLogic)
+        logic.poop_items = [object()]
+        logic.max_poop = 1
+        logic.squid = SimpleNamespace()
+
+        self.assertFalse(logic.spawn_poop(100, 200))
+
+    def test_spawn_poop_reports_success_after_scene_insertion(self):
+        logic = object.__new__(TamagotchiLogic)
+        logic.poop_items = []
+        logic.max_poop = 1
+        logic.squid = SimpleNamespace(
+            poop_images=[object()],
+            poop_width=20,
+            mark_scene_objects_dirty=Mock(),
+        )
+        logic.user_interface = SimpleNamespace(
+            scene=SimpleNamespace(addItem=Mock()),
+        )
+        logic.brain_hooks = SimpleNamespace(on_object_spawned=Mock())
+        poop_item = SimpleNamespace(setPos=Mock())
+
+        with patch(
+            "src.tamagotchi_logic.ResizablePixmapItem",
+            return_value=poop_item,
+        ):
+            created = logic.spawn_poop(100, 200)
+
+        self.assertTrue(created)
+        self.assertEqual(logic.poop_items, [poop_item])
+        poop_item.setPos.assert_called_once_with(90, 200)
+        logic.user_interface.scene.addItem.assert_called_once_with(poop_item)
+        logic.brain_hooks.on_object_spawned.assert_called_once_with("poop")
+        logic.squid.mark_scene_objects_dirty.assert_called_once_with()
+
+    def test_direct_approach_records_actual_distance(self):
+        squid = object.__new__(Squid)
+        squid.squid_x = 100
+        squid.squid_y = 100
+        squid.squid_width = 20
+        squid.squid_height = 20
+        squid.base_squid_speed = 90
+        squid.base_vertical_speed = 45
+        squid.animation_speed = 1
+        squid.current_frame = 0
+        squid.squid_item = SimpleNamespace(
+            sceneBoundingRect=lambda: SimpleNamespace(
+                center=lambda: SimpleNamespace(
+                    x=lambda: 100,
+                    y=lambda: 100,
+                ),
+            ),
+            setPos=Mock(),
+        )
+        squid.ui = SimpleNamespace(window_width=1000, window_height=800)
+        squid.update_squid_image = Mock()
+        squid.tamagotchi_logic = SimpleNamespace(track_distance=Mock())
+
+        remaining_distance = squid.move_toward_position((300, 100))
+
+        self.assertEqual(remaining_distance, 200)
+        self.assertEqual((squid.squid_x, squid.squid_y), (190, 100))
+        squid.tamagotchi_logic.track_distance.assert_called_once_with(90)
+
+    def test_diagonal_approach_records_euclidean_distance(self):
+        squid = object.__new__(Squid)
+        squid.squid_x = 100
+        squid.squid_y = 100
+        squid.squid_width = 20
+        squid.squid_height = 20
+        squid.base_squid_speed = 5
+        squid.base_vertical_speed = 5
+        squid.animation_speed = 1
+        squid.current_frame = 0
+        squid.squid_item = SimpleNamespace(
+            sceneBoundingRect=lambda: SimpleNamespace(
+                center=lambda: SimpleNamespace(
+                    x=lambda: 100,
+                    y=lambda: 100,
+                ),
+            ),
+            setPos=Mock(),
+        )
+        squid.ui = SimpleNamespace(window_width=1000, window_height=800)
+        squid.update_squid_image = Mock()
+        squid.tamagotchi_logic = SimpleNamespace(track_distance=Mock())
+
+        remaining_distance = squid.move_toward_position((106, 108))
+
+        self.assertEqual(remaining_distance, 10)
+        self.assertEqual((squid.squid_x, squid.squid_y), (103, 104))
+        squid.tamagotchi_logic.track_distance.assert_called_once_with(5)
+
+    def test_normal_and_clipped_movement_record_post_clamp_distance(self):
+        for direction, start, expected_position, expected_distance in (
+            ("down", (100, 100), (100, 145), 45),
+            ("right", (840, 100), (850, 100), 10),
+        ):
+            with self.subTest(direction=direction):
+                squid = object.__new__(Squid)
+                squid.squid_x, squid.squid_y = start
+                squid.squid_width = 100
+                squid.squid_height = 20
+                squid.base_squid_speed = 90
+                squid.base_vertical_speed = 45
+                squid.animation_speed = 1
+                squid.is_sleeping = False
+                squid.squid_direction = direction
+                squid.current_frame = 0
+                squid.pursuing_food = False
+                squid.last_view_cone_change = 0
+                squid.view_cone_change_interval = 100_000_000
+                squid.ui = SimpleNamespace(
+                    window_width=1000,
+                    window_height=800,
+                )
+                squid.tamagotchi_logic = SimpleNamespace(
+                    track_distance=Mock(),
+                )
+                squid.squid_item = SimpleNamespace(
+                    setPixmap=Mock(),
+                    setPos=Mock(),
+                )
+                squid.get_visible_food = Mock(return_value=[])
+                squid.move_randomly = Mock()
+                squid.change_direction = Mock()
+                squid.current_image = Mock(return_value=None)
+                squid.update_view_cone = Mock()
+                squid.update_sick_icon_position = Mock()
+
+                squid.move_squid()
+
+                self.assertEqual(
+                    (squid.squid_x, squid.squid_y),
+                    expected_position,
+                )
+                squid.tamagotchi_logic.track_distance.assert_called_once_with(
+                    expected_distance,
+                )
+
+    def test_sleeping_movement_records_actual_distance(self):
+        squid = object.__new__(Squid)
+        squid.squid_x = 100
+        squid.squid_y = 100
+        squid.squid_width = 100
+        squid.squid_height = 20
+        squid.base_vertical_speed = 45
+        squid.animation_speed = 1
+        squid.is_sleeping = True
+        squid.current_frame = 0
+        squid.ui = SimpleNamespace(
+            window_width=1000,
+            window_height=800,
+        )
+        squid.tamagotchi_logic = SimpleNamespace(
+            track_distance=Mock(),
+        )
+        squid.squid_item = SimpleNamespace(setPos=Mock())
+        squid.update_squid_image = Mock()
+
+        squid.move_squid()
+
+        self.assertEqual((squid.squid_x, squid.squid_y), (100, 145))
+        squid.tamagotchi_logic.track_distance.assert_called_once_with(45)
 
 
 if __name__ == "__main__":

--- a/tests/test_statistics_event_wiring.py
+++ b/tests/test_statistics_event_wiring.py
@@ -4,8 +4,12 @@ from contextlib import redirect_stdout
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
+from src.brain_about_tab import AboutTab
 from src.brain_widget import BrainWidget
+from src.interactions import RockInteractionManager
+from src.interactions2 import PoopInteractionManager
 from src.neurogenesis import EnhancedNeurogenesis
+from src.squid import Squid
 from src.squid_statistics import SquidStatistics
 from src.tamagotchi_logic import TamagotchiLogic
 
@@ -282,6 +286,268 @@ class StatisticsEventWiringTests(unittest.TestCase):
         logic.track_startle()
 
         self.assertEqual(squid.statistics.startles_experienced, 1)
+
+    def test_discrete_events_do_not_depend_on_statistics_tab(self):
+        squid = FakeSquid()
+        logic = object.__new__(TamagotchiLogic)
+        logic.squid = squid
+        logic.brain_window = SimpleNamespace(statistics_tab=None)
+        logic.poop_items = [object(), object(), object()]
+
+        logic.track_food_consumed(SimpleNamespace(is_sushi=True))
+        logic.track_food_consumed(SimpleNamespace(is_sushi=False))
+        logic.track_poop_created()
+        logic.track_poop_thrown()
+        logic.track_rock_thrown()
+        logic.track_plant_interaction()
+        logic.track_colour_changed()
+        logic.track_distance(80)
+
+        self.assertEqual(squid.statistics.sushi_consumed, 1)
+        self.assertEqual(squid.statistics.cheese_consumed, 1)
+        self.assertEqual(squid.statistics.poops_created, 1)
+        self.assertEqual(squid.statistics.max_poops_cleaned, 3)
+        self.assertEqual(squid.statistics.total_poops_thrown, 1)
+        self.assertEqual(squid.statistics.total_rocks_thrown, 1)
+        self.assertEqual(squid.statistics.plants_interacted, 1)
+        self.assertEqual(squid.statistics.times_colour_changed, 1)
+        self.assertEqual(squid.statistics.distance_swam, 80)
+
+    def test_real_ink_cloud_path_is_safe_without_statistics_tab(self):
+        squid = FakeSquid()
+        squid.squid_x = 0
+        squid.squid_y = 0
+        squid.squid_width = 20
+        squid.squid_height = 20
+        squid.ui = SimpleNamespace(
+            scene=SimpleNamespace(addItem=Mock()),
+        )
+
+        logic = object.__new__(TamagotchiLogic)
+        logic.squid = squid
+        logic.brain_window = SimpleNamespace(statistics_tab=None)
+        logic.statistics_window = SimpleNamespace(award=Mock())
+
+        pixmap = Mock()
+        pixmap.width.return_value = 10
+        pixmap.height.return_value = 10
+        ink_cloud_item = Mock()
+        opacity_effect = Mock()
+        animation = Mock()
+
+        with (
+            patch(
+                "src.tamagotchi_logic.QtGui.QPixmap",
+                return_value=pixmap,
+            ),
+            patch(
+                "src.tamagotchi_logic.QtWidgets.QGraphicsPixmapItem",
+                return_value=ink_cloud_item,
+            ),
+            patch(
+                "src.tamagotchi_logic.QtWidgets.QGraphicsOpacityEffect",
+                return_value=opacity_effect,
+            ),
+            patch(
+                "src.tamagotchi_logic.QtCore.QPropertyAnimation",
+                return_value=animation,
+            ),
+            patch(
+                "src.tamagotchi_logic.QtCore.QTimer.singleShot"
+            ) as single_shot,
+        ):
+            logic.create_ink_cloud()
+
+        self.assertEqual(squid.statistics.ink_clouds_created, 1)
+        logic.statistics_window.award.assert_called_once_with(-250)
+        squid.ui.scene.addItem.assert_called_once_with(ink_cloud_item)
+        single_shot.assert_called_once()
+        self.assertEqual(single_shot.call_args.args[0], 10000)
+
+    def test_legacy_peak_memory_and_age_updates_are_model_owned(self):
+        squid = FakeSquid()
+        squid.memory_manager = SimpleNamespace(
+            short_term_memory=[1, 2, 3],
+            long_term_memory=[1, 2, 3, 4],
+        )
+        logic = object.__new__(TamagotchiLogic)
+        logic.squid = squid
+        logic.brain_window = SimpleNamespace(statistics_tab=None)
+
+        logic.update_squid_age()
+        logic.update_highest_anxiety(75)
+        logic.update_highest_anxiety(50)
+        logic.update_lowest_happiness(20)
+        logic.update_lowest_happiness(40)
+        logic.update_max_memories()
+
+        squid.memory_manager.short_term_memory.clear()
+        squid.memory_manager.long_term_memory.clear()
+        logic.update_max_memories()
+
+        persisted = squid.statistics.to_dict()
+        self.assertEqual(persisted["highest_anxiety"], 75)
+        self.assertEqual(persisted["lowest_happiness"], 20)
+        self.assertEqual(persisted["max_short_term_memories"], 3)
+        self.assertEqual(persisted["max_long_term_memories"], 4)
+
+    def test_rock_throw_delivers_one_model_event(self):
+        squid = FakeSquid()
+        rock_rect = SimpleNamespace(
+            width=lambda: 2,
+            height=lambda: 4,
+        )
+        rock = SimpleNamespace(
+            filename="rock.png",
+            setParentItem=Mock(),
+            boundingRect=lambda: rock_rect,
+            setPos=Mock(),
+            setVisible=Mock(),
+        )
+        squid.carried_rock = rock
+        squid.status = "roaming"
+        squid.happiness = 50
+        squid.satisfaction = 50
+        squid.anxiety = 50
+        squid.squid_item = SimpleNamespace(
+            sceneBoundingRect=lambda: SimpleNamespace(
+                center=lambda: SimpleNamespace(
+                    x=lambda: 10,
+                    y=lambda: 20,
+                )
+            )
+        )
+        squid.memory_manager = SimpleNamespace(
+            add_short_term_memory=Mock(),
+        )
+
+        statistics_tab = SimpleNamespace(
+            increment_stat=lambda name, amount=1: squid.statistics.increment(
+                name,
+                amount,
+            ),
+            update_statistics=Mock(),
+        )
+        logic = object.__new__(TamagotchiLogic)
+        logic.squid = squid
+        logic.brain_window = SimpleNamespace(statistics_tab=statistics_tab)
+        logic.statistics_window = SimpleNamespace(award=Mock())
+
+        manager = object.__new__(RockInteractionManager)
+        manager.squid = squid
+        manager.logic = logic
+        manager.rock_config = {
+            "happiness_boost": 5,
+            "satisfaction_boost": 3,
+            "anxiety_reduction": 2,
+        }
+        manager.throw_animation_timer = Mock()
+        manager.throw_animation_timer.isActive.return_value = False
+        manager.multiplayer_plugin = None
+
+        self.assertTrue(manager.throw_rock())
+        self.assertEqual(squid.statistics.total_rocks_thrown, 1)
+        statistics_tab.update_statistics.assert_called_once_with()
+
+    def test_poop_throw_delivers_one_model_event(self):
+        squid = FakeSquid()
+        poop_rect = SimpleNamespace(
+            width=lambda: 2,
+            height=lambda: 4,
+        )
+        poop = SimpleNamespace(
+            filename="poop.png",
+            setParentItem=Mock(),
+            boundingRect=lambda: poop_rect,
+            setPos=Mock(),
+            setVisible=Mock(),
+        )
+        squid.carried_poop = poop
+        squid.status = "roaming"
+        squid.happiness = 50
+        squid.satisfaction = 50
+        squid.anxiety = 50
+        squid.squid_item = SimpleNamespace(
+            sceneBoundingRect=lambda: SimpleNamespace(
+                center=lambda: SimpleNamespace(
+                    x=lambda: 10,
+                    y=lambda: 20,
+                )
+            )
+        )
+        squid.memory_manager = SimpleNamespace(
+            add_short_term_memory=Mock(),
+        )
+
+        statistics_tab = SimpleNamespace(update_statistics=Mock())
+        logic = object.__new__(TamagotchiLogic)
+        logic.squid = squid
+        logic.brain_window = SimpleNamespace(statistics_tab=statistics_tab)
+        logic.statistics_window = SimpleNamespace(award=Mock())
+
+        manager = object.__new__(PoopInteractionManager)
+        manager.squid = squid
+        manager.logic = logic
+        manager.poop_config = {}
+        manager.throw_animation_timer = Mock()
+        manager.throw_animation_timer.isActive.return_value = False
+        manager.multiplayer_plugin = None
+
+        self.assertTrue(manager.throw_poop())
+        self.assertEqual(squid.statistics.total_poops_thrown, 1)
+        statistics_tab.update_statistics.assert_called_once_with()
+
+    def test_plant_completion_delivers_one_model_event(self):
+        squid = FakeSquid()
+        squid.curiosity = 10
+        squid.memory_manager = SimpleNamespace(
+            add_short_term_memory=Mock(),
+            add_long_term_memory=Mock(),
+            plant_interaction_count={},
+        )
+        squid.push_animation = object()
+
+        statistics_tab = SimpleNamespace(
+            increment_stat=Mock(),
+            update_statistics=Mock(),
+        )
+        logic = object.__new__(TamagotchiLogic)
+        logic.squid = squid
+        logic.brain_window = SimpleNamespace(statistics_tab=statistics_tab)
+        logic.recent_positive_outcome = False
+        logic.show_message = Mock()
+        squid.tamagotchi_logic = logic
+
+        Squid._on_push_complete(
+            squid,
+            SimpleNamespace(category="plant", filename="fern.png"),
+        )
+        Squid._on_push_complete(
+            squid,
+            SimpleNamespace(category="rock", filename="rock.png"),
+        )
+
+        self.assertEqual(squid.statistics.plants_interacted, 1)
+        statistics_tab.increment_stat.assert_not_called()
+        statistics_tab.update_statistics.assert_called_once_with()
+
+    def test_colour_change_delivers_one_model_event_without_tab(self):
+        squid = FakeSquid()
+        squid.apply_tint = Mock()
+        logic = object.__new__(TamagotchiLogic)
+        logic.squid = squid
+        logic.brain_window = SimpleNamespace(statistics_tab=None)
+        controller = SimpleNamespace(tamagotchi_logic=logic)
+        colour = SimpleNamespace(isValid=lambda: True)
+
+        with patch(
+            "src.brain_about_tab.QtWidgets.QColorDialog.getColor",
+            return_value=colour,
+        ):
+            AboutTab.open_color_picker(controller)
+
+        squid.apply_tint.assert_called_once_with(colour)
+        self.assertEqual(squid.statistics.times_colour_changed, 1)
 
     def test_sickness_funnel_keeps_state_and_transition_count_aligned(self):
         squid = FakeSquid()

--- a/tests/test_statistics_event_wiring.py
+++ b/tests/test_statistics_event_wiring.py
@@ -2,7 +2,7 @@ import io
 import unittest
 from contextlib import redirect_stdout
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from src.brain_widget import BrainWidget
 from src.neurogenesis import EnhancedNeurogenesis
@@ -138,7 +138,17 @@ class StatisticsEventWiringTests(unittest.TestCase):
         squid = FakeSquid()
         neuron_name = "reward_test"
         brain_widget = SimpleNamespace(
-            neuron_positions={f"neuron_{index}": (0, 0) for index in range(9)},
+            neuron_positions={
+                **{f"neuron_{index}": (0, 0) for index in range(9)},
+                "is_sick": (0, 0),
+            },
+            excluded_neurons=[
+                "is_sick",
+                "is_eating",
+                "pursuing_food",
+                "direction",
+                "is_sleeping",
+            ],
             enhanced_neurogenesis=SimpleNamespace(
                 functional_neurons={
                     neuron_name: SimpleNamespace(neuron_type="reward"),
@@ -152,6 +162,9 @@ class StatisticsEventWiringTests(unittest.TestCase):
             brain_widget=brain_widget,
             statistics_tab=None,
         )
+        logic.statistics_window = SimpleNamespace(
+            add_score_for_neuron_creation=Mock(),
+        )
 
         with patch("src.tamagotchi_logic.QtCore.QTimer.singleShot") as single_shot:
             logic._on_neurogenesis_icon_and_memory(neuron_name)
@@ -159,10 +172,95 @@ class StatisticsEventWiringTests(unittest.TestCase):
         self.assertEqual(squid.statistics.reward_neurons_created, 1)
         self.assertEqual(squid.statistics.current_neurons, 9)
         self.assertEqual(squid.statistics.max_neurons_reached, 9)
+        logic.statistics_window.add_score_for_neuron_creation.assert_called_once_with()
         single_shot.assert_called_once_with(
             0,
-            logic._observe_current_neuron_count,
+            logic.refresh_neuron_count,
         )
+
+    def test_live_neuron_count_filters_only_excluded_position_keys(self):
+        logic = object.__new__(TamagotchiLogic)
+        logic.brain_window = SimpleNamespace(
+            brain_widget=SimpleNamespace(
+                neuron_positions={
+                    **{f"core_{index}": (0, 0) for index in range(8)},
+                    "is_sick": (0, 0),
+                },
+                excluded_neurons=[
+                    "is_sick",
+                    "is_eating",
+                    "pursuing_food",
+                    "direction",
+                    "is_sleeping",
+                ],
+            )
+        )
+
+        self.assertEqual(logic._live_neuron_count(), 8)
+
+    def test_sleep_elapsed_time_stays_wall_clock_at_faster_speeds(self):
+        logic = object.__new__(TamagotchiLogic)
+
+        for speed in (1, 2, 3):
+            with self.subTest(speed=speed):
+                interval_ms = 1000 // speed
+                logic.simulation_timer = SimpleNamespace(
+                    interval=lambda value=interval_ms: value
+                )
+                elapsed = sum(
+                    logic._statistics_elapsed_seconds()
+                    for _ in range(speed)
+                )
+                self.assertAlmostEqual(elapsed, 1.0, places=2)
+
+    def test_startle_ink_followup_runs_only_when_cloud_is_created(self):
+        memory_manager = SimpleNamespace(
+            add_short_term_memory=Mock(),
+        )
+        squid = SimpleNamespace(
+            status="startled",
+            memory_manager=memory_manager,
+            end_ink_flee=Mock(),
+        )
+        logic = object.__new__(TamagotchiLogic)
+        logic.squid = squid
+        logic.create_ink_cloud = Mock()
+
+        with (
+            patch("src.tamagotchi_logic.random.random", return_value=0.5),
+            patch("src.tamagotchi_logic.QtCore.QTimer.singleShot") as single_shot,
+        ):
+            self.assertFalse(logic._maybe_create_startle_ink_cloud("environment"))
+
+        logic.create_ink_cloud.assert_not_called()
+        memory_manager.add_short_term_memory.assert_not_called()
+        single_shot.assert_not_called()
+        self.assertEqual(squid.status, "startled")
+
+        with (
+            patch("src.tamagotchi_logic.random.random", return_value=0.1),
+            patch("src.tamagotchi_logic.QtCore.QTimer.singleShot") as single_shot,
+        ):
+            self.assertTrue(logic._maybe_create_startle_ink_cloud("environment"))
+
+        logic.create_ink_cloud.assert_called_once_with()
+        memory_manager.add_short_term_memory.assert_called_once_with(
+            'behaviour',
+            'ink_cloud',
+            'Startled! Created an ink cloud',
+        )
+        single_shot.assert_called_once_with(5000, squid.end_ink_flee)
+        self.assertEqual(squid.status, "fleeing!")
+
+    def test_startle_count_does_not_depend_on_statistics_tab(self):
+        squid = FakeSquid()
+        logic = object.__new__(TamagotchiLogic)
+        logic.squid = squid
+        logic.brain_window = SimpleNamespace(statistics_tab=None)
+
+        logic.track_startle()
+
+        self.assertEqual(squid.statistics.startles_experienced, 1)
 
     def test_sickness_funnel_keeps_state_and_transition_count_aligned(self):
         squid = FakeSquid()

--- a/tests/test_statistics_persistence.py
+++ b/tests/test_statistics_persistence.py
@@ -75,6 +75,19 @@ class StatisticsPersistenceTests(unittest.TestCase):
                 self.assertEqual(restored.max_neurons_reached, 11)
                 self.assertEqual(restored.novelty_neurons_created, 2)
 
+    def test_load_preserves_a_lifetime_maximum_above_current_count(self):
+        restored = SquidStatistics(FakeSquid())
+
+        restored.load_statistics(
+            {
+                "current_neurons": 8,
+                "max_neurons_reached": 15,
+            }
+        )
+
+        self.assertEqual(restored.current_neurons, 8)
+        self.assertEqual(restored.max_neurons_reached, 15)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_statistics_persistence.py
+++ b/tests/test_statistics_persistence.py
@@ -88,6 +88,34 @@ class StatisticsPersistenceTests(unittest.TestCase):
         self.assertEqual(restored.current_neurons, 8)
         self.assertEqual(restored.max_neurons_reached, 15)
 
+    def test_reset_neuron_counts_survive_save_archive_round_trip(self):
+        statistics = SquidStatistics(FakeSquid())
+        statistics.observe_neuron_count(12)
+        statistics.observe_neuron_count(9)
+        statistics.reset()
+
+        with tempfile.TemporaryDirectory() as save_directory:
+            manager = SaveManager(save_directory)
+            with redirect_stdout(io.StringIO()):
+                archive_path = manager.save_game(
+                    {
+                        "game_state": {
+                            "squid": {
+                                "uuid": "00000000-0000-0000-0000-000000000026",
+                            }
+                        },
+                        "statistics": statistics.to_dict(),
+                    }
+                )
+            self.assertIsNotNone(archive_path)
+            loaded_archive = manager.load_game()
+
+        restored = SquidStatistics(FakeSquid())
+        restored.load_statistics(loaded_archive["statistics"])
+
+        self.assertEqual(restored.current_neurons, 9)
+        self.assertEqual(restored.max_neurons_reached, 12)
+
     def test_every_canonical_persistence_key_round_trips(self):
         statistics = SquidStatistics(FakeSquid())
         expected_attributes = {}

--- a/tests/test_statistics_persistence.py
+++ b/tests/test_statistics_persistence.py
@@ -1,10 +1,47 @@
 import io
+import json
 import tempfile
 import unittest
+import zipfile
 from contextlib import redirect_stdout
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
 
 from src.save_manager import SaveManager
 from src.squid_statistics import SquidStatistics
+from src.tamagotchi_logic import TamagotchiLogic
+
+
+EXPECTED_PERSISTENCE_KEYS = {
+    "distance_swam": "distance_swam",
+    "distance_swam_multiplier": "distance_swam_multiplier",
+    "sushi_eaten": "sushi_consumed",
+    "cheese_eaten": "cheese_consumed",
+    "total_memories_formed": "total_memories_formed",
+    "max_short_term_memories": "max_short_term_memories",
+    "max_long_term_memories": "max_long_term_memories",
+    "highest_anxiety": "highest_anxiety",
+    "lowest_happiness": "lowest_happiness",
+    "highest_satisfaction": "highest_satisfaction",
+    "other_squids_encountered": "other_squids_encountered",
+    "rocks_thrown": "total_rocks_thrown",
+    "poops_thrown": "total_poops_thrown",
+    "total_env_interactions": "total_env_interactions",
+    "ink_clouds_created": "ink_clouds_created",
+    "plants_interacted": "plants_interacted",
+    "total_sleep_time": "time_spent_asleep",
+    "peak_novelty": "peak_novelty",
+    "peak_stress": "peak_stress",
+    "peak_reward": "peak_reward",
+    "novelty_neurons_created": "novelty_neurons_created",
+    "stress_neurons_created": "stress_neurons_created",
+    "reward_neurons_created": "reward_neurons_created",
+    "poops_created": "poops_created",
+    "max_poops_cleaned": "max_poops_cleaned",
+    "startles_experienced": "startles_experienced",
+    "times_colour_changed": "times_colour_changed",
+    "sickness_episodes": "sickness_episodes",
+}
 
 
 class FakeSquid:
@@ -16,7 +53,59 @@ class FakeSquid:
         self.is_sick = is_sick
 
 
+class LoaderSquid(FakeSquid):
+    def __init__(self, *, is_sick=False):
+        super().__init__(is_sick=is_sick)
+        self.statistics = SquidStatistics(self)
+        self.memory_manager = SimpleNamespace(
+            short_term_memory=[],
+            long_term_memory=[],
+        )
+        self.mental_state_manager = SimpleNamespace(set_state=Mock())
+
+    def load_state(self, state):
+        for attribute_name, value in state.items():
+            setattr(self, attribute_name, value)
+
+
+def make_loader_logic(squid):
+    logic = object.__new__(TamagotchiLogic)
+    logic.squid = squid
+    logic.user_interface = SimpleNamespace(
+        load_decorations_data=Mock(),
+    )
+    logic.brain_window = SimpleNamespace(
+        brain_widget=SimpleNamespace(),
+        set_brain_state=Mock(),
+    )
+    logic.statistics_window = SimpleNamespace(
+        set_score=Mock(),
+        update_statistics=Mock(),
+    )
+    logic.refresh_neuron_count = Mock()
+    logic.set_simulation_speed = Mock()
+    return logic
+
+
 class StatisticsPersistenceTests(unittest.TestCase):
+    def test_persistence_schema_keeps_every_canonical_field(self):
+        statistics = SquidStatistics(FakeSquid())
+
+        self.assertEqual(
+            statistics._PERSISTENCE_KEYS,
+            EXPECTED_PERSISTENCE_KEYS,
+        )
+        self.assertEqual(
+            set(statistics.to_dict()),
+            set(EXPECTED_PERSISTENCE_KEYS)
+            | {
+                "total_age_seconds",
+                "squid_age_minutes",
+                "max_neurons_reached",
+                "current_neurons",
+            },
+        )
+
     def test_statistics_survive_save_archive_round_trip(self):
         squid = FakeSquid()
         statistics = SquidStatistics(squid)
@@ -57,6 +146,194 @@ class StatisticsPersistenceTests(unittest.TestCase):
 
         restored.record_sickness_state(True)
         self.assertEqual(restored.sickness_episodes, 1)
+
+    def test_partial_load_replaces_absent_live_session_values(self):
+        statistics = SquidStatistics(FakeSquid())
+        statistics.sushi_consumed = 9
+        statistics.distance_swam = 500
+        statistics.sickness_episodes = 4
+        statistics.observe_neuron_count(12)
+
+        statistics.load_statistics({"cheese_eaten": 2})
+
+        self.assertEqual(statistics.cheese_consumed, 2)
+        self.assertEqual(statistics.sushi_consumed, 0)
+        self.assertEqual(statistics.distance_swam, 0)
+        self.assertEqual(statistics.sickness_episodes, 0)
+        self.assertEqual(statistics.current_neurons, 8)
+        self.assertEqual(statistics.max_neurons_reached, 8)
+
+    def test_empty_load_replaces_the_entire_live_session(self):
+        statistics = SquidStatistics(FakeSquid())
+        statistics.cheese_consumed = 2
+        statistics.sushi_consumed = 9
+        statistics.distance_swam = 500
+        statistics.sickness_episodes = 4
+        statistics.observe_neuron_count(12)
+
+        statistics.load_statistics({})
+
+        self.assertEqual(statistics.cheese_consumed, 0)
+        self.assertEqual(statistics.sushi_consumed, 0)
+        self.assertEqual(statistics.distance_swam, 0)
+        self.assertEqual(statistics.sickness_episodes, 0)
+        self.assertEqual(statistics.current_neurons, 8)
+        self.assertEqual(statistics.max_neurons_reached, 8)
+
+    def test_apply_save_data_replaces_absent_live_statistics(self):
+        squid = LoaderSquid()
+        squid.statistics.sushi_consumed = 9
+        squid.statistics.distance_swam = 500
+        squid.statistics.sickness_episodes = 4
+        logic = make_loader_logic(squid)
+        save_data = {
+            "game_state": {
+                "squid": {"is_sick": True},
+                "decorations": [],
+                "tamagotchi_logic": {
+                    "cleanliness_threshold_time": 1,
+                    "hunger_threshold_time": 2,
+                    "last_clean_time": 3,
+                    "points": 4,
+                },
+            },
+            "statistics": {"cheese_eaten": 2},
+        }
+
+        with (
+            redirect_stdout(io.StringIO()),
+            patch(
+                "src.tamagotchi_logic.show_custom_brain_load_warning",
+                return_value=True,
+            ),
+        ):
+            loaded = logic._apply_save_data(save_data)
+
+        self.assertTrue(loaded)
+        self.assertEqual(squid.statistics.cheese_consumed, 2)
+        self.assertEqual(squid.statistics.sushi_consumed, 0)
+        self.assertEqual(squid.statistics.distance_swam, 0)
+        self.assertEqual(squid.statistics.sickness_episodes, 0)
+        squid.mental_state_manager.set_state.assert_called_once_with(
+            "sick",
+            True,
+        )
+        logic.statistics_window.set_score.assert_called_once_with(4)
+        logic.statistics_window.update_statistics.assert_called_once_with()
+
+    def test_zip_load_replaces_absent_live_statistics(self):
+        squid = LoaderSquid()
+        squid.statistics.sushi_consumed = 9
+        squid.statistics.distance_swam = 500
+        squid.statistics.sickness_episodes = 4
+        logic = make_loader_logic(squid)
+
+        with tempfile.TemporaryDirectory() as save_directory:
+            archive_path = (
+                f"{save_directory}/partial-statistics.zip"
+            )
+            with zipfile.ZipFile(archive_path, "w") as archive:
+                archive.writestr(
+                    "game_state.json",
+                    json.dumps(
+                        {
+                            "squid": {"is_sick": True},
+                            "decorations": [],
+                            "tamagotchi_logic": {"points": 7},
+                        }
+                    ),
+                )
+                archive.writestr(
+                    "statistics.json",
+                    json.dumps({"cheese_eaten": 2}),
+                )
+
+            logic.save_manager = SimpleNamespace(
+                get_latest_save=lambda: archive_path,
+            )
+            with redirect_stdout(io.StringIO()):
+                loaded = logic.load_game()
+
+        self.assertTrue(loaded)
+        self.assertEqual(squid.statistics.cheese_consumed, 2)
+        self.assertEqual(squid.statistics.sushi_consumed, 0)
+        self.assertEqual(squid.statistics.distance_swam, 0)
+        self.assertEqual(squid.statistics.sickness_episodes, 0)
+        squid.mental_state_manager.set_state.assert_called_once_with(
+            "sick",
+            True,
+        )
+        logic.statistics_window.set_score.assert_called_once_with(7)
+        logic.statistics_window.update_statistics.assert_called_once_with()
+
+    def test_apply_save_data_without_statistics_resets_live_values(self):
+        squid = LoaderSquid()
+        squid.statistics.cheese_consumed = 2
+        squid.statistics.sushi_consumed = 9
+        squid.statistics.distance_swam = 500
+        squid.statistics.sickness_episodes = 4
+        logic = make_loader_logic(squid)
+        save_data = {
+            "game_state": {
+                "squid": {"is_sick": False},
+                "decorations": [],
+                "tamagotchi_logic": {
+                    "cleanliness_threshold_time": 1,
+                    "hunger_threshold_time": 2,
+                    "last_clean_time": 3,
+                    "points": 4,
+                },
+            },
+        }
+
+        with (
+            redirect_stdout(io.StringIO()),
+            patch(
+                "src.tamagotchi_logic.show_custom_brain_load_warning",
+                return_value=True,
+            ),
+        ):
+            loaded = logic._apply_save_data(save_data)
+
+        self.assertTrue(loaded)
+        self.assertEqual(squid.statistics.cheese_consumed, 0)
+        self.assertEqual(squid.statistics.sushi_consumed, 0)
+        self.assertEqual(squid.statistics.distance_swam, 0)
+        self.assertEqual(squid.statistics.sickness_episodes, 0)
+
+    def test_zip_load_without_statistics_resets_live_values(self):
+        squid = LoaderSquid()
+        squid.statistics.cheese_consumed = 2
+        squid.statistics.sushi_consumed = 9
+        squid.statistics.distance_swam = 500
+        squid.statistics.sickness_episodes = 4
+        logic = make_loader_logic(squid)
+
+        with tempfile.TemporaryDirectory() as save_directory:
+            archive_path = f"{save_directory}/no-statistics.zip"
+            with zipfile.ZipFile(archive_path, "w") as archive:
+                archive.writestr(
+                    "game_state.json",
+                    json.dumps(
+                        {
+                            "squid": {"is_sick": False},
+                            "decorations": [],
+                            "tamagotchi_logic": {"points": 7},
+                        }
+                    ),
+                )
+
+            logic.save_manager = SimpleNamespace(
+                get_latest_save=lambda: archive_path,
+            )
+            with redirect_stdout(io.StringIO()):
+                loaded = logic.load_game()
+
+        self.assertTrue(loaded)
+        self.assertEqual(squid.statistics.cheese_consumed, 0)
+        self.assertEqual(squid.statistics.sushi_consumed, 0)
+        self.assertEqual(squid.statistics.distance_swam, 0)
+        self.assertEqual(squid.statistics.sickness_episodes, 0)
 
     def test_legacy_current_count_repairs_an_invalid_lifetime_maximum(self):
         for saved_maximum in (None, 0, 5):

--- a/tests/test_statistics_persistence.py
+++ b/tests/test_statistics_persistence.py
@@ -88,6 +88,27 @@ class StatisticsPersistenceTests(unittest.TestCase):
         self.assertEqual(restored.current_neurons, 8)
         self.assertEqual(restored.max_neurons_reached, 15)
 
+    def test_every_canonical_persistence_key_round_trips(self):
+        statistics = SquidStatistics(FakeSquid())
+        expected_attributes = {}
+        for index, attribute_name in enumerate(
+            statistics._PERSISTENCE_KEYS.values(),
+            start=1,
+        ):
+            value = index + 0.25
+            setattr(statistics, attribute_name, value)
+            expected_attributes[attribute_name] = value
+
+        restored = SquidStatistics(FakeSquid())
+        restored.load_statistics(statistics.to_dict())
+
+        for attribute_name, expected_value in expected_attributes.items():
+            with self.subTest(attribute_name=attribute_name):
+                self.assertEqual(
+                    getattr(restored, attribute_name),
+                    expected_value,
+                )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_statistics_persistence.py
+++ b/tests/test_statistics_persistence.py
@@ -1,0 +1,80 @@
+import io
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+
+from src.save_manager import SaveManager
+from src.squid_statistics import SquidStatistics
+
+
+class FakeSquid:
+    def __init__(self, *, is_sick=False):
+        self.anxiety = 10
+        self.happiness = 90
+        self.satisfaction = 20
+        self.is_sleeping = False
+        self.is_sick = is_sick
+
+
+class StatisticsPersistenceTests(unittest.TestCase):
+    def test_statistics_survive_save_archive_round_trip(self):
+        squid = FakeSquid()
+        statistics = SquidStatistics(squid)
+        squid.is_sleeping = True
+        statistics.update(elapsed_seconds=12.5)
+        statistics.record_sickness_state(True)
+        statistics.record_sickness_state(True)
+        statistics.record_neuron_birth("novelty", current_count=8)
+        statistics.record_neuron_birth("reward", current_count=9)
+        statistics.observe_neuron_count(8)
+
+        with tempfile.TemporaryDirectory() as save_directory:
+            manager = SaveManager(save_directory)
+            with redirect_stdout(io.StringIO()):
+                archive_path = manager.save_game(
+                    {
+                        "game_state": {
+                            "squid": {
+                                "uuid": "00000000-0000-0000-0000-000000000026",
+                            }
+                        },
+                        "statistics": statistics.to_dict(),
+                    }
+                )
+            self.assertIsNotNone(archive_path)
+            loaded_archive = manager.load_game()
+
+        restored_squid = FakeSquid(is_sick=True)
+        restored = SquidStatistics(restored_squid)
+        restored.load_statistics(loaded_archive["statistics"])
+
+        self.assertEqual(restored.time_spent_asleep, 12.5)
+        self.assertEqual(restored.sickness_episodes, 1)
+        self.assertEqual(restored.novelty_neurons_created, 1)
+        self.assertEqual(restored.reward_neurons_created, 1)
+        self.assertEqual(restored.current_neurons, 8)
+        self.assertEqual(restored.max_neurons_reached, 9)
+
+        restored.record_sickness_state(True)
+        self.assertEqual(restored.sickness_episodes, 1)
+
+    def test_legacy_current_count_repairs_an_invalid_lifetime_maximum(self):
+        for saved_maximum in (None, 0, 5):
+            with self.subTest(saved_maximum=saved_maximum):
+                restored = SquidStatistics(FakeSquid())
+                saved_statistics = {
+                    "current_neurons": 11,
+                    "novelty_neurons_created": 2,
+                }
+                if saved_maximum is not None:
+                    saved_statistics["max_neurons_reached"] = saved_maximum
+
+                restored.load_statistics(saved_statistics)
+
+                self.assertEqual(restored.current_neurons, 11)
+                self.assertEqual(restored.max_neurons_reached, 11)
+                self.assertEqual(restored.novelty_neurons_created, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_statistics_persistence.py
+++ b/tests/test_statistics_persistence.py
@@ -180,6 +180,141 @@ class StatisticsPersistenceTests(unittest.TestCase):
         self.assertEqual(statistics.current_neurons, 8)
         self.assertEqual(statistics.max_neurons_reached, 8)
 
+    def test_malformed_numeric_values_fall_back_without_poisoning_model(self):
+        squid = FakeSquid()
+        statistics = SquidStatistics(squid)
+
+        statistics.load_statistics(
+            {
+                "total_age_seconds": "12.5",
+                "distance_swam": "42.25",
+                "total_sleep_time": None,
+                "sickness_episodes": "not-a-number",
+                "highest_anxiety": float("inf"),
+                "cheese_eaten": True,
+                "peak_stress": "1.75",
+                "current_neurons": "9",
+                "max_neurons_reached": "invalid",
+            }
+        )
+
+        self.assertEqual(statistics.total_age_seconds, 12.5)
+        self.assertEqual(statistics.distance_swam, 42.25)
+        self.assertEqual(statistics.time_spent_asleep, 0)
+        self.assertEqual(statistics.sickness_episodes, 0)
+        self.assertEqual(statistics.highest_anxiety, 0)
+        self.assertEqual(statistics.cheese_consumed, 0)
+        self.assertEqual(statistics.peak_stress, 1.75)
+        self.assertEqual(statistics.current_neurons, 9)
+        self.assertEqual(statistics.max_neurons_reached, 9)
+
+        squid.is_sleeping = True
+        statistics.update(elapsed_seconds=0.5)
+        statistics.add_distance(0.75)
+        statistics.increment("cheese_eaten")
+
+        self.assertEqual(statistics.time_spent_asleep, 0.5)
+        self.assertEqual(statistics.distance_swam, 43)
+        self.assertEqual(statistics.cheese_consumed, 1)
+
+    def test_malformed_neuron_counts_fall_back_to_the_live_default(self):
+        malformed_counts = (
+            None,
+            True,
+            -1,
+            9.5,
+            "9.5",
+            float("nan"),
+            float("inf"),
+            [],
+            {},
+        )
+
+        for malformed_count in malformed_counts:
+            with self.subTest(malformed_count=malformed_count):
+                statistics = SquidStatistics(FakeSquid())
+                statistics.load_statistics(
+                    {
+                        "current_neurons": malformed_count,
+                        "max_neurons_reached": malformed_count,
+                    }
+                )
+
+                self.assertEqual(statistics.current_neurons, 8)
+                self.assertEqual(statistics.max_neurons_reached, 8)
+
+    def test_both_public_loaders_accept_malformed_numeric_statistics(self):
+        malformed_statistics = {
+            "distance_swam": "not-a-number",
+            "total_sleep_time": None,
+            "sickness_episodes": "4",
+            "current_neurons": "9",
+            "max_neurons_reached": "invalid",
+        }
+
+        apply_squid = LoaderSquid()
+        apply_logic = make_loader_logic(apply_squid)
+        save_data = {
+            "game_state": {
+                "squid": {"is_sick": False},
+                "decorations": [],
+                "tamagotchi_logic": {
+                    "cleanliness_threshold_time": 1,
+                    "hunger_threshold_time": 2,
+                    "last_clean_time": 3,
+                    "points": 4,
+                },
+            },
+            "statistics": malformed_statistics,
+        }
+
+        with (
+            redirect_stdout(io.StringIO()),
+            patch(
+                "src.tamagotchi_logic.show_custom_brain_load_warning",
+                return_value=True,
+            ),
+        ):
+            self.assertTrue(apply_logic._apply_save_data(save_data))
+
+        self.assertEqual(apply_squid.statistics.distance_swam, 0)
+        self.assertEqual(apply_squid.statistics.time_spent_asleep, 0)
+        self.assertEqual(apply_squid.statistics.sickness_episodes, 4)
+        self.assertEqual(apply_squid.statistics.current_neurons, 9)
+        self.assertEqual(apply_squid.statistics.max_neurons_reached, 9)
+
+        zip_squid = LoaderSquid()
+        zip_logic = make_loader_logic(zip_squid)
+        with tempfile.TemporaryDirectory() as save_directory:
+            archive_path = f"{save_directory}/malformed-statistics.zip"
+            with zipfile.ZipFile(archive_path, "w") as archive:
+                archive.writestr(
+                    "game_state.json",
+                    json.dumps(
+                        {
+                            "squid": {"is_sick": False},
+                            "decorations": [],
+                            "tamagotchi_logic": {"points": 7},
+                        }
+                    ),
+                )
+                archive.writestr(
+                    "statistics.json",
+                    json.dumps(malformed_statistics),
+                )
+
+            zip_logic.save_manager = SimpleNamespace(
+                get_latest_save=lambda: archive_path,
+            )
+            with redirect_stdout(io.StringIO()):
+                self.assertTrue(zip_logic.load_game())
+
+        self.assertEqual(zip_squid.statistics.distance_swam, 0)
+        self.assertEqual(zip_squid.statistics.time_spent_asleep, 0)
+        self.assertEqual(zip_squid.statistics.sickness_episodes, 4)
+        self.assertEqual(zip_squid.statistics.current_neurons, 9)
+        self.assertEqual(zip_squid.statistics.max_neurons_reached, 9)
+
     def test_apply_save_data_replaces_absent_live_statistics(self):
         squid = LoaderSquid()
         squid.statistics.sushi_consumed = 9

--- a/tests/test_statistics_persistence.py
+++ b/tests/test_statistics_persistence.py
@@ -8,9 +8,8 @@ from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 from src.save_manager import SaveManager
-from src.squid_statistics import SquidStatistics
+from src.squid_statistics import DEFAULT_NEURON_COUNT, SquidStatistics
 from src.tamagotchi_logic import TamagotchiLogic
-
 
 EXPECTED_PERSISTENCE_KEYS = {
     "distance_swam": "distance_swam",
@@ -42,6 +41,15 @@ EXPECTED_PERSISTENCE_KEYS = {
     "times_colour_changed": "times_colour_changed",
     "sickness_episodes": "sickness_episodes",
 }
+
+def malformed_numeric_statistics():
+    return {
+        "distance_swam": "not-a-number",
+        "total_sleep_time": None,
+        "sickness_episodes": "4",
+        "current_neurons": "9",
+        "max_neurons_reached": "invalid",
+    }
 
 
 class FakeSquid:
@@ -160,8 +168,11 @@ class StatisticsPersistenceTests(unittest.TestCase):
         self.assertEqual(statistics.sushi_consumed, 0)
         self.assertEqual(statistics.distance_swam, 0)
         self.assertEqual(statistics.sickness_episodes, 0)
-        self.assertEqual(statistics.current_neurons, 8)
-        self.assertEqual(statistics.max_neurons_reached, 8)
+        self.assertEqual(statistics.current_neurons, DEFAULT_NEURON_COUNT)
+        self.assertEqual(
+            statistics.max_neurons_reached,
+            DEFAULT_NEURON_COUNT,
+        )
 
     def test_empty_load_replaces_the_entire_live_session(self):
         statistics = SquidStatistics(FakeSquid())
@@ -177,8 +188,11 @@ class StatisticsPersistenceTests(unittest.TestCase):
         self.assertEqual(statistics.sushi_consumed, 0)
         self.assertEqual(statistics.distance_swam, 0)
         self.assertEqual(statistics.sickness_episodes, 0)
-        self.assertEqual(statistics.current_neurons, 8)
-        self.assertEqual(statistics.max_neurons_reached, 8)
+        self.assertEqual(statistics.current_neurons, DEFAULT_NEURON_COUNT)
+        self.assertEqual(
+            statistics.max_neurons_reached,
+            DEFAULT_NEURON_COUNT,
+        )
 
     def test_malformed_numeric_values_fall_back_without_poisoning_model(self):
         squid = FakeSquid()
@@ -240,20 +254,25 @@ class StatisticsPersistenceTests(unittest.TestCase):
                     }
                 )
 
-                self.assertEqual(statistics.current_neurons, 8)
-                self.assertEqual(statistics.max_neurons_reached, 8)
+                self.assertEqual(
+                    statistics.current_neurons,
+                    DEFAULT_NEURON_COUNT,
+                )
+                self.assertEqual(
+                    statistics.max_neurons_reached,
+                    DEFAULT_NEURON_COUNT,
+                )
 
-    def test_both_public_loaders_accept_malformed_numeric_statistics(self):
-        malformed_statistics = {
-            "distance_swam": "not-a-number",
-            "total_sleep_time": None,
-            "sickness_episodes": "4",
-            "current_neurons": "9",
-            "max_neurons_reached": "invalid",
-        }
+    def assert_malformed_statistics_loaded(self, statistics):
+        self.assertEqual(statistics.distance_swam, 0)
+        self.assertEqual(statistics.time_spent_asleep, 0)
+        self.assertEqual(statistics.sickness_episodes, 4)
+        self.assertEqual(statistics.current_neurons, 9)
+        self.assertEqual(statistics.max_neurons_reached, 9)
 
-        apply_squid = LoaderSquid()
-        apply_logic = make_loader_logic(apply_squid)
+    def test_apply_save_data_accepts_malformed_numeric_statistics(self):
+        squid = LoaderSquid()
+        logic = make_loader_logic(squid)
         save_data = {
             "game_state": {
                 "squid": {"is_sick": False},
@@ -265,7 +284,7 @@ class StatisticsPersistenceTests(unittest.TestCase):
                     "points": 4,
                 },
             },
-            "statistics": malformed_statistics,
+            "statistics": malformed_numeric_statistics(),
         }
 
         with (
@@ -275,16 +294,13 @@ class StatisticsPersistenceTests(unittest.TestCase):
                 return_value=True,
             ),
         ):
-            self.assertTrue(apply_logic._apply_save_data(save_data))
+            self.assertTrue(logic._apply_save_data(save_data))
 
-        self.assertEqual(apply_squid.statistics.distance_swam, 0)
-        self.assertEqual(apply_squid.statistics.time_spent_asleep, 0)
-        self.assertEqual(apply_squid.statistics.sickness_episodes, 4)
-        self.assertEqual(apply_squid.statistics.current_neurons, 9)
-        self.assertEqual(apply_squid.statistics.max_neurons_reached, 9)
+        self.assert_malformed_statistics_loaded(squid.statistics)
 
-        zip_squid = LoaderSquid()
-        zip_logic = make_loader_logic(zip_squid)
+    def test_zip_loader_accepts_malformed_numeric_statistics(self):
+        squid = LoaderSquid()
+        logic = make_loader_logic(squid)
         with tempfile.TemporaryDirectory() as save_directory:
             archive_path = f"{save_directory}/malformed-statistics.zip"
             with zipfile.ZipFile(archive_path, "w") as archive:
@@ -300,20 +316,16 @@ class StatisticsPersistenceTests(unittest.TestCase):
                 )
                 archive.writestr(
                     "statistics.json",
-                    json.dumps(malformed_statistics),
+                    json.dumps(malformed_numeric_statistics()),
                 )
 
-            zip_logic.save_manager = SimpleNamespace(
+            logic.save_manager = SimpleNamespace(
                 get_latest_save=lambda: archive_path,
             )
             with redirect_stdout(io.StringIO()):
-                self.assertTrue(zip_logic.load_game())
+                self.assertTrue(logic.load_game())
 
-        self.assertEqual(zip_squid.statistics.distance_swam, 0)
-        self.assertEqual(zip_squid.statistics.time_spent_asleep, 0)
-        self.assertEqual(zip_squid.statistics.sickness_episodes, 4)
-        self.assertEqual(zip_squid.statistics.current_neurons, 9)
-        self.assertEqual(zip_squid.statistics.max_neurons_reached, 9)
+        self.assert_malformed_statistics_loaded(squid.statistics)
 
     def test_zip_loader_preserves_model_for_nested_legacy_statistics(self):
         squid = LoaderSquid()

--- a/tests/test_statistics_persistence.py
+++ b/tests/test_statistics_persistence.py
@@ -315,6 +315,38 @@ class StatisticsPersistenceTests(unittest.TestCase):
         self.assertEqual(zip_squid.statistics.current_neurons, 9)
         self.assertEqual(zip_squid.statistics.max_neurons_reached, 9)
 
+    def test_zip_loader_preserves_model_for_nested_legacy_statistics(self):
+        squid = LoaderSquid()
+        original_statistics = squid.statistics
+        logic = make_loader_logic(squid)
+
+        with tempfile.TemporaryDirectory() as save_directory:
+            archive_path = f"{save_directory}/nested-statistics.zip"
+            with zipfile.ZipFile(archive_path, "w") as archive:
+                archive.writestr(
+                    "game_state.json",
+                    json.dumps(
+                        {
+                            "squid": {
+                                "is_sick": False,
+                                "statistics": {"distance_swam": 7},
+                            },
+                            "decorations": [],
+                            "tamagotchi_logic": {"points": 0},
+                        }
+                    ),
+                )
+
+            logic.save_manager = SimpleNamespace(
+                get_latest_save=lambda: archive_path,
+            )
+            with redirect_stdout(io.StringIO()):
+                loaded = logic.load_game()
+
+        self.assertTrue(loaded)
+        self.assertIs(squid.statistics, original_statistics)
+        self.assertEqual(squid.statistics.distance_swam, 7)
+
     def test_apply_save_data_replaces_absent_live_statistics(self):
         squid = LoaderSquid()
         squid.statistics.sushi_consumed = 9

--- a/tests/test_statistics_tab_lifecycle.py
+++ b/tests/test_statistics_tab_lifecycle.py
@@ -132,6 +132,25 @@ class StatisticsTabLifecycleTests(unittest.TestCase):
                 logic.brain_window = window
                 logic.neuron_output_monitor = None
 
+                prebound_stats = logic.squid.statistics
+                self.assertTrue(prebound_stats.increment("cheese_eaten"))
+                prebound_stats.add_distance(1000)
+                prebound_stats.sushi_consumed = 2
+                prebound_stats.poops_created = 3
+                prebound_stats.max_poops_cleaned = 4
+                prebound_stats.startles_experienced = 5
+                prebound_stats.ink_clouds_created = 6
+                prebound_stats.times_colour_changed = 7
+                prebound_stats.total_rocks_thrown = 8
+                prebound_stats.plants_interacted = 9
+                prebound_stats.time_spent_asleep = 125
+                prebound_stats.sickness_episodes = 10
+                prebound_stats.novelty_neurons_created = 11
+                prebound_stats.stress_neurons_created = 12
+                prebound_stats.reward_neurons_created = 13
+                prebound_stats.observe_neuron_count(14)
+                prebound_stats.total_age_seconds = 15 * 60
+
                 window.set_tamagotchi_logic(logic)
 
                 for tab_name in (
@@ -148,18 +167,135 @@ class StatisticsTabLifecycleTests(unittest.TestCase):
                         logic,
                     )
 
+                labels = window.statistics_tab.stat_labels
+                expected_initial_labels = {
+                    "squid_age_minutes": "15",
+                    "distance_swam": "1,000",
+                    "cheese_eaten": "1",
+                    "sushi_eaten": "2",
+                    "poops_created": "3",
+                    "max_poops_cleaned": "4",
+                    "startles_experienced": "5",
+                    "ink_clouds_created": "6",
+                    "times_colour_changed": "7",
+                    "rocks_thrown": "8",
+                    "plants_interacted": "9",
+                    "total_sleep_time": "125",
+                    "sickness_episodes": "10",
+                    "novelty_neurons_created": "11",
+                    "stress_neurons_created": "12",
+                    "reward_neurons_created": "13",
+                    "current_neurons": "14",
+                }
+                for label_name, expected_text in (
+                    expected_initial_labels.items()
+                ):
+                    with self.subTest(
+                        phase="initial bind",
+                        label_name=label_name,
+                    ):
+                        self.assertEqual(
+                            labels[label_name].text(),
+                            expected_text,
+                        )
+
+                prebound_stats.reset()
                 self.assertTrue(logic.record_statistic_event("cheese_eaten"))
                 logic.track_distance(4321)
-                logic.squid.statistics.observe_neuron_count(13)
+                logic.squid.statistics.observe_neuron_count(15)
                 logic._refresh_statistics_tab()
 
-                labels = window.statistics_tab.stat_labels
                 self.assertEqual(logic.squid.statistics.cheese_consumed, 1)
                 self.assertEqual(logic.squid.statistics.distance_swam, 4321.0)
-                self.assertEqual(logic.squid.statistics.max_neurons_reached, 13)
+                self.assertEqual(logic.squid.statistics.max_neurons_reached, 15)
                 self.assertEqual(labels["cheese_eaten"].text(), "1")
                 self.assertEqual(labels["distance_swam"].text(), "4,321")
-                self.assertEqual(labels["current_neurons"].text(), "13")
+                self.assertEqual(labels["current_neurons"].text(), "15")
+
+                window.set_tamagotchi_logic(None)
+                self.assertIsNone(window.tamagotchi_logic)
+                self.assertIsNone(window.brain_widget.tamagotchi_logic)
+                for tab_name in (
+                    "network_tab",
+                    "nn_viz_tab",
+                    "memory_tab",
+                    "decisions_tab",
+                    "personality_tab",
+                    "statistics_tab",
+                    "about_tab",
+                ):
+                    self.assertIsNone(
+                        getattr(window, tab_name).tamagotchi_logic
+                    )
+
+                replacement_logic = object.__new__(TamagotchiLogic)
+                replacement_logic.squid = FakeSquid()
+                replacement_logic.brain_window = window
+                replacement_logic.neuron_output_monitor = None
+                replacement_stats = replacement_logic.squid.statistics
+                replacement_stats.increment("cheese_eaten", 21)
+                replacement_stats.add_distance(2000)
+                replacement_stats.sushi_consumed = 22
+                replacement_stats.poops_created = 23
+                replacement_stats.max_poops_cleaned = 24
+                replacement_stats.startles_experienced = 25
+                replacement_stats.ink_clouds_created = 26
+                replacement_stats.times_colour_changed = 27
+                replacement_stats.total_rocks_thrown = 28
+                replacement_stats.plants_interacted = 29
+                replacement_stats.time_spent_asleep = 240
+                replacement_stats.sickness_episodes = 30
+                replacement_stats.novelty_neurons_created = 31
+                replacement_stats.stress_neurons_created = 32
+                replacement_stats.reward_neurons_created = 33
+                replacement_stats.observe_neuron_count(34)
+                replacement_stats.total_age_seconds = 35 * 60
+
+                window.set_tamagotchi_logic(replacement_logic)
+
+                for tab_name in (
+                    "network_tab",
+                    "nn_viz_tab",
+                    "memory_tab",
+                    "decisions_tab",
+                    "personality_tab",
+                    "statistics_tab",
+                    "about_tab",
+                ):
+                    self.assertIs(
+                        getattr(window, tab_name).tamagotchi_logic,
+                        replacement_logic,
+                    )
+                expected_replacement_labels = {
+                    "squid_age_minutes": "35",
+                    "distance_swam": "2,000",
+                    "cheese_eaten": "21",
+                    "sushi_eaten": "22",
+                    "poops_created": "23",
+                    "max_poops_cleaned": "24",
+                    "startles_experienced": "25",
+                    "ink_clouds_created": "26",
+                    "times_colour_changed": "27",
+                    "rocks_thrown": "28",
+                    "plants_interacted": "29",
+                    "total_sleep_time": "240",
+                    "sickness_episodes": "30",
+                    "novelty_neurons_created": "31",
+                    "stress_neurons_created": "32",
+                    "reward_neurons_created": "33",
+                    "current_neurons": "34",
+                }
+                for label_name, expected_text in (
+                    expected_replacement_labels.items()
+                ):
+                    with self.subTest(
+                        phase="replacement bind",
+                        label_name=label_name,
+                    ):
+                        self.assertEqual(
+                            labels[label_name].text(),
+                            expected_text,
+                        )
             finally:
                 if window is not None:
                     for timer in window.findChildren(QtCore.QTimer):

--- a/tests/test_statistics_tab_lifecycle.py
+++ b/tests/test_statistics_tab_lifecycle.py
@@ -1,0 +1,177 @@
+import io
+import os
+import unittest
+from contextlib import ExitStack, redirect_stdout
+from unittest.mock import patch
+
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from PyQt5 import QtCore, QtWidgets
+
+import src.brain_tool as brain_tool_module
+import src.brain_widget as brain_widget_module
+from src.squid_statistics import SquidStatistics
+from src.tamagotchi_logic import TamagotchiLogic
+
+
+class FakeSignal:
+    def connect(self, *_args):
+        pass
+
+    def disconnect(self, *_args):
+        pass
+
+    def emit(self, *_args):
+        pass
+
+
+class FakeRenderWorker:
+    def __init__(self, *_args, **_kwargs):
+        self.render_complete = FakeSignal()
+
+    def start(self):
+        pass
+
+    def stop(self):
+        pass
+
+    def wait(self, *_args):
+        return True
+
+    def request_render(self, *_args, **_kwargs):
+        pass
+
+
+class FakeBrainWorker:
+    def __init__(self, *_args, **_kwargs):
+        self.neurogenesis_result = FakeSignal()
+        self.hebbian_result = FakeSignal()
+        self.state_update_result = FakeSignal()
+        self.error_occurred = FakeSignal()
+
+    def start(self):
+        pass
+
+    def stop(self):
+        pass
+
+    def wait(self, *_args):
+        return True
+
+    def isRunning(self):
+        return False
+
+    def update_cache(self, *_args, **_kwargs):
+        pass
+
+
+class FakeTaskManager(QtWidgets.QWidget):
+    def __init__(self, _worker, parent=None):
+        super().__init__(parent)
+
+
+class FakeSquid:
+    def __init__(self):
+        self.anxiety = 10
+        self.happiness = 90
+        self.satisfaction = 20
+        self.is_sleeping = False
+        self.is_sick = False
+        self.statistics = SquidStatistics(self)
+
+
+class StatisticsTabLifecycleTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+
+    def test_late_logic_wiring_projects_model_statistics_into_real_tab(self):
+        window = None
+        with ExitStack() as stack:
+            stack.enter_context(
+                patch.object(
+                    brain_widget_module,
+                    "BrainRenderWorker",
+                    FakeRenderWorker,
+                )
+            )
+            stack.enter_context(
+                patch.object(brain_widget_module, "_HAS_BRAIN_BRIDGE", False)
+            )
+            stack.enter_context(
+                patch.object(brain_tool_module, "BrainWorker", FakeBrainWorker)
+            )
+            stack.enter_context(
+                patch.object(
+                    brain_tool_module,
+                    "TaskManagerWindow",
+                    FakeTaskManager,
+                )
+            )
+            stack.enter_context(
+                patch.object(brain_tool_module, "_HAS_BRAIN_BRIDGE", False)
+            )
+            stack.enter_context(redirect_stdout(io.StringIO()))
+
+            try:
+                window = brain_tool_module.SquidBrainWindow(
+                    None,
+                    debug_mode=False,
+                    config=None,
+                )
+                self.assertEqual(window.tabs.count(), 7)
+                self.assertGreaterEqual(
+                    window.tabs.indexOf(window.statistics_tab),
+                    0,
+                )
+                self.assertIsNone(window.statistics_tab.tamagotchi_logic)
+
+                logic = object.__new__(TamagotchiLogic)
+                logic.squid = FakeSquid()
+                logic.brain_window = window
+                logic.neuron_output_monitor = None
+
+                window.set_tamagotchi_logic(logic)
+
+                for tab_name in (
+                    "network_tab",
+                    "nn_viz_tab",
+                    "memory_tab",
+                    "decisions_tab",
+                    "personality_tab",
+                    "statistics_tab",
+                    "about_tab",
+                ):
+                    self.assertIs(
+                        getattr(window, tab_name).tamagotchi_logic,
+                        logic,
+                    )
+
+                self.assertTrue(logic.record_statistic_event("cheese_eaten"))
+                logic.track_distance(4321)
+                logic.squid.statistics.observe_neuron_count(13)
+                logic._refresh_statistics_tab()
+
+                labels = window.statistics_tab.stat_labels
+                self.assertEqual(logic.squid.statistics.cheese_consumed, 1)
+                self.assertEqual(logic.squid.statistics.distance_swam, 4321.0)
+                self.assertEqual(logic.squid.statistics.max_neurons_reached, 13)
+                self.assertEqual(labels["cheese_eaten"].text(), "1")
+                self.assertEqual(labels["distance_swam"].text(), "4,321")
+                self.assertEqual(labels["current_neurons"].text(), "13")
+            finally:
+                if window is not None:
+                    for timer in window.findChildren(QtCore.QTimer):
+                        timer.stop()
+                    window.close()
+                    window.deleteLater()
+                    QtCore.QCoreApplication.sendPostedEvents(
+                        None,
+                        QtCore.QEvent.DeferredDelete,
+                    )
+                    self.app.processEvents()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_statistics_tab_lifecycle.py
+++ b/tests/test_statistics_tab_lifecycle.py
@@ -11,7 +11,7 @@ from PyQt5 import QtCore, QtWidgets
 
 import src.brain_tool as brain_tool_module
 import src.brain_widget as brain_widget_module
-from src.squid_statistics import SquidStatistics
+from src.squid_statistics import DEFAULT_NEURON_COUNT, SquidStatistics
 from src.tamagotchi_logic import TamagotchiLogic
 
 
@@ -125,12 +125,17 @@ class StatisticsTabLifecycleTests(unittest.TestCase):
                     window.tabs.indexOf(window.statistics_tab),
                     0,
                 )
+                self.assertFalse(hasattr(window, "learning_tab"))
                 self.assertIsNone(window.statistics_tab.tamagotchi_logic)
 
                 logic = object.__new__(TamagotchiLogic)
                 logic.squid = FakeSquid()
                 logic.brain_window = window
                 logic.neuron_output_monitor = None
+                self.assertEqual(
+                    logic._live_neuron_count(),
+                    DEFAULT_NEURON_COUNT,
+                )
 
                 prebound_stats = logic.squid.statistics
                 self.assertTrue(prebound_stats.increment("cheese_eaten"))


### PR DESCRIPTION
I'm sincerely sorry for #41. It made the Statistics tab worse and cost you time to merge, test, and revert it. You were right to revert it. I should have tested the real desktop Qt startup path before asking you to merge the change, and I did not.

## Root cause

Both desktop entrypoints create `SquidBrainWindow` before `TamagotchiLogic`, then attach the completed logic later through `SquidBrainWindow.set_tamagotchi_logic()`.

When I changed `StatisticsTab` into a read-only view of the canonical `SquidStatistics` model, I failed to update that late-injection path. Its propagation loop omitted `statistics_tab` and `personality_tab` and referenced `learning_tab` instead of the real `nn_viz_tab`. The Statistics tab never received the model it had been changed to display, so its refresh methods returned early and its labels remained at their initial placeholder values.

The tests submitted with #41 covered model, event-delivery, persistence, and reset behavior with fakes, but never constructed the real seven-tab startup sequence. I mistook unit coverage for GUI integration coverage. That validation failure was mine.

## Repair

This restores the complete reverted statistics change rather than applying a lifecycle-only patch: the issue requires the statistics to be recorded and persisted correctly, not merely for the tab to display a model.

- propagate the late-created logic to all seven real brain tabs, including clear and replacement rebinds
- immediately synchronize and render `StatisticsTab` after binding
- keep lifetime statistics model-owned and the tab read-only
- make partial, legacy, and missing statistics payloads replace the current model through both desktop load entrypoints
- record actual post-boundary Euclidean movement for normal, direct, diagonal, clipped, and sleeping paths
- count a poop only after its scene insertion succeeds and count an accepted click wake exactly once
- disconnect a stopped game's neurogenesis listener so a replacement game cannot double-handle one birth
- preserve exactly-once sickness, event, persistence, reset, and neuron-maximum behavior

## Final R4 review fixes

CodeRabbit's completed review of the submitted R3 head found two additional real defects, and both are fixed in this update:

- observe `peak_novelty`, `peak_stress`, and `peak_reward` from the current production neurogenesis triggers immediately after they update, using the same stress scale as the neurogenesis brain state and preserving lifetime maxima while live values decay
- sanitize persisted numeric values at the model boundary so `None`, booleans, negatives, NaN/Infinity, malformed strings, containers, and fractional neuron counts cannot poison or crash the model through either desktop loader

The update also preserves the former zero-argument `SquidStatistics.update()` and one-argument `track_neuron_creation()` APIs, derives the standard neuron count from the real eight-position `BrainWidget`, and drives the real synchronous neurogenesis method instead of stubbing the behavior under test.

## Final takeover review fixes

A fresh final-head audit found one more production writer outside `track_neurogenesis_triggers()`: eating could raise the live reward trigger from 4 to its cap of 5, then the same simulation callback could decay it to 4.8 before the lifetime peak was observed. The food-consumption boundary now records the canonical live maximum immediately after writing it. A regression drives the real `Squid.eat()` and `TamagotchiLogic.track_neurogenesis_triggers()` methods through that exact sequence and proves the live value may decay to 4.8 while `peak_reward` remains 5.

A subsequent exact-head audit found that the direct ZIP loader's generic squid-state loop could replace the canonical `SquidStatistics` instance with a nested legacy statistics dictionary, then fail when it called the model loader. The loader now preserves the model owner, prefers the current top-level `statistics.json`, and falls back to the supported nested legacy payload when that file is absent. A regression drives the real ZIP loader and proves loading succeeds, the model identity is preserved, and the nested value is restored.

## Final R7 review fixes

CodeRabbit's review of the exact R6 head identified an unsafe legacy poop-target
guard. If `current_poop_target` exists but is `None`, the simulation callback
tested only whether the attribute existed and then called
`sceneBoundingRect()` on `None`. The repository currently has no production
assignment of a poop item to this legacy target attribute, so the review's
proposed successful-throw sequence is not reachable as described. The guard is
still hardened for a missing, cleared, or externally supplied target, and a
regression invokes the real interaction method with both absent and `None`
states.

The same review found that the legacy `update_distance(dx, dy)` entrypoint
duplicated older single-rollover logic. A sufficiently large step could cross
multiple rollover boundaries but increment the multiplier only once. It now
delegates to the validated `add_distance()` implementation and preserves its
existing rollover notification. A regression crosses three boundaries in one
step and verifies the exact remainder, multiplier, and message.

Unsupported event keys still return `False` without changing state. They now
also emit a debug log so a future typo or incomplete event mapping is visible
during development.

The review's remaining test-only findings were handled without changing
production semantics: default-neuron assertions use
`DEFAULT_NEURON_COUNT`, and the two public malformed-statistics loader
scenarios now report independently. The proposed `__init__` reset refactor was
not applied because no defect was present and preserving the old `start_time`
across a load would risk counting pre-load session time again.

## Regression evidence

A focused reproduction invokes the production late-injection method against a real `StatisticsTab`. It fails on the exact merged #41 tree and on the audited upstream base because `StatisticsTab.tamagotchi_logic` remains `None`; it passes with this repair.

A separate offscreen Qt regression constructs the real `SquidBrainWindow`, `BrainWidget`, `QTabWidget`, all seven real tabs, and their `QLabel` values. It exercises `logic1 -> None -> logic2`, verifies every real tab reference at each stage, proves the window has no ghost `learning_tab`, derives the eight-neuron baseline from the real widget, and asserts all 17 displayed statistics with distinct values on both initial binding and replacement rebinding.

Additional integration tests exercise both real save-loading entrypoints with malformed, partial, missing, and nested legacy statistics payloads. Movement tests cover horizontal, vertical, boundary-clipped, sleeping, direct, and diagonal Euclidean displacement. Event tests cover accepted and rejected poop creation, repeated click wake, signal cleanup, real synchronous neurogenesis creation, the food-writer reward peak, and compatibility call forms.

Fifteen earlier targeted mutation checks cover the R6 repair's model, load,
peak, lifecycle, and exactly-once invariants. Three additional R7 mutation
checks confirm that the new regression tests fail if the cleared-target guard,
multi-rollover delegation, or unknown-event debug logging is removed.

## Testing

- `python -m pytest tests -q` (57 passed, 87 subtests passed)
- `python -m pytest android/tests -q` (7 passed)
- `python -m compileall -q src tests android`
- Ruff import/error checks on all R7-changed model and test files
- no additional Ruff diagnostics in the changed production files
- CRLF-aware R7 added-line whitespace check
- 3/3 R7-targeted mutants killed

Two fresh packet-only reviews found the food-boundary peak loss in R4 and the legacy-loader model replacement in R5. Both findings were independently reproduced and fixed in transparent successor commits. The exact R7 packet is reviewed separately before submission; reviewer execution limitations and the verdict are preserved in the submission evidence rather than represented as local test execution here.

The GUI lifecycle regression is offscreen and stubs background workers, bridge I/O, and task-manager UI. It uses the real window, widget, tabs, labels, injection order, model, and relevant production methods. No interactive visual smoke was performed for this model-boundary R7 update.

Closes #26


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized gameplay statistics for actions, movement, sickness, memories, sleep, and neuron growth.
  * Improved statistics persistence, save/load compatibility, resetting, and display synchronization.
  * Added accurate movement-distance and successful-poop tracking.
  * Improved neuron-creation notifications and live neuron-count updates.

* **Bug Fixes**
  * Prevented duplicate event recording and corrected startle, sickness, and interaction counts.
  * Ensured statistics remain accurate when the statistics panel is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
